### PR TITLE
Remove build config that is not needed anymore

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,18 +81,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-maven-plugin</artifactId>
-                <version>${jetty.version}</version>
-                <configuration>
-                    <!-- To serve Grid's static resources like gridConnector.js -->
-                    <webAppSourceDirectory>${project.basedir}/src/main/resources/META-INF/resources</webAppSourceDirectory>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/src/test/java/com/vaadin/ui/grid/GridView.java
+++ b/src/test/java/com/vaadin/ui/grid/GridView.java
@@ -43,11 +43,6 @@ import com.vaadin.ui.textfield.TextField;
 /**
  * View for {@link Grid} demo.
  */
-// @Route(value = "vaadin-grid", layout = MainLayout.class)
-// @ComponentDemo(name = "Grid")
-// @HtmlImport("bower_components/vaadin-valo-theme/vaadin-grid.html")
-// @HtmlImport("bower_components/vaadin-valo-theme/vaadin-button.html")
-// @HtmlImport("bower_components/vaadin-valo-theme/vaadin-text-field.html")
 @Route("vaadin-grid")
 @HtmlImport("bower_components/vaadin-valo-theme/vaadin-grid.html")
 @HtmlImport("bower_components/vaadin-valo-theme/vaadin-button.html")


### PR DESCRIPTION
The same result is now implemented in the parent-pom via https://github.com/vaadin/flow-component-base/pull/26

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-flow/16)
<!-- Reviewable:end -->
