### PR TITLE
Make Grid add columns based on bean properties

### DIFF
--- a/src/main/java/com/vaadin/ui/grid/Grid.java
+++ b/src/main/java/com/vaadin/ui/grid/Grid.java
@@ -985,8 +985,8 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
                     .getProperty(propertyName).get();
             return addColumn(property);
         } catch (NoSuchElementException exception) {
-            throw new IllegalArgumentException("Can't resolve property name "
-                    + propertyName + " from " + propertySet);
+            throw new IllegalArgumentException("Can't resolve property name '"
+                    + propertyName + "' from '" + propertySet + "'");
         }
     }
 

--- a/src/main/java/com/vaadin/ui/grid/Grid.java
+++ b/src/main/java/com/vaadin/ui/grid/Grid.java
@@ -980,14 +980,14 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
         }
         Objects.requireNonNull(propertyName, "Property name can't be null");
 
+        PropertyDefinition<T, ?> property;
         try {
-            PropertyDefinition<T, ?> property = propertySet
-                    .getProperty(propertyName).get();
-            return addColumn(property);
-        } catch (NoSuchElementException exception) {
+            property = propertySet.getProperty(propertyName).get();
+        } catch (NoSuchElementException | IllegalArgumentException exception) {
             throw new IllegalArgumentException("Can't resolve property name '"
                     + propertyName + "' from '" + propertySet + "'");
         }
+        return addColumn(property);
     }
 
     private Column<T> addColumn(PropertyDefinition<T, ?> property) {

--- a/src/main/java/com/vaadin/ui/grid/Grid.java
+++ b/src/main/java/com/vaadin/ui/grid/Grid.java
@@ -25,14 +25,18 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.BinaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.vaadin.data.BeanPropertySet;
 import com.vaadin.data.Binder;
 import com.vaadin.data.HasDataProvider;
+import com.vaadin.data.PropertyDefinition;
+import com.vaadin.data.PropertySet;
 import com.vaadin.data.event.SortEvent;
 import com.vaadin.data.event.SortEvent.SortNotifier;
 import com.vaadin.data.provider.ArrayUpdater;
@@ -786,6 +790,8 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
 
     private final List<GridSortOrder<T>> sortOrder = new ArrayList<>();
 
+    private PropertySet<T> propertySet;
+
     /**
      * Creates a new instance, with page size of 50.
      */
@@ -812,6 +818,28 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
         getElement().getNode()
                 .runWhenAttached(ui -> ui.getPage().executeJavaScript(
                         "window.gridConnector.initLazy($0)", getElement()));
+    }
+
+    /**
+     * Creates a new grid with an initial set of columns for each of the bean's
+     * properties. The property-values of the bean will be converted to Strings.
+     * Full names of the properties will be used as the
+     * {@link Column#setKey(String) column keys} and the property captions will
+     * be used as the {@link Column#setHeader(String) column headers}.
+     * <p>
+     * You can add columns for nested properties of the bean with
+     * {@link #addColumn(String)}.
+     *
+     * @param beanType
+     *            the bean type to use, not <code>null</code>
+     */
+    public Grid(Class<T> beanType) {
+        this();
+        Objects.requireNonNull(beanType, "Bean type can't be null");
+        propertySet = BeanPropertySet.get(beanType);
+        propertySet.getProperties()
+                .filter(property -> !property.isSubProperty())
+                .forEach(this::addColumn);
     }
 
     /**
@@ -929,6 +957,53 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
     }
 
     /**
+     * <strong>Note:</strong> This method can only be used for a Grid created
+     * from a bean type with {@link #Grid(Class)}.
+     * <p>
+     * Adds a new column for the given property name. The property values are
+     * converted to Strings in the grid cells. The property's full name will be
+     * used as the {@link Column#setKey(String) column key} and the property
+     * caption will be used as the {@link Column#setHeader(String) column
+     * header}.
+     * <p>
+     * You can add columns for nested properties with dot notation, eg.
+     * <code>"property.nestedProperty"</code>
+     *
+     * @param propertyName
+     *            the property name of the new column, not <code>null</code>
+     * @return the created column
+     */
+    public Column<T> addColumn(String propertyName) {
+        if (propertySet == null) {
+            throw new UnsupportedOperationException(
+                    "This method can't be used for a Grid that isn't constructed from a bean type");
+        }
+        Objects.requireNonNull(propertyName, "Property name can't be null");
+
+        try {
+            PropertyDefinition<T, ?> property = propertySet
+                    .getProperty(propertyName).get();
+            return addColumn(property);
+        } catch (NoSuchElementException exception) {
+            throw new IllegalArgumentException("Can't resolve property name "
+                    + propertyName + " from " + propertySet);
+        }
+    }
+
+    private Column<T> addColumn(PropertyDefinition<T, ?> property) {
+        Column<T> column = addColumn(
+                item -> String.valueOf(property.getGetter().apply(item)))
+                        .setHeader(property.getCaption());
+        try {
+            return column.setKey(property.getFullName());
+        } catch (IllegalArgumentException exception) {
+            throw new IllegalArgumentException(
+                    "Multiple columns for the same property: "
+                            + property.getFullName());
+        }
+    }
+
+    /**
      * Sets a user-defined identifier for given column.
      *
      * @see Column#setKey(String)
@@ -940,7 +1015,8 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
      */
     protected void setColumnKey(String key, Column column) {
         if (keyToColumnMap.containsKey(key)) {
-            throw new IllegalArgumentException("Duplicate key for columns");
+            throw new IllegalArgumentException(
+                    "Duplicate key for columns: " + key);
         }
         keyToColumnMap.put(key, column);
     }
@@ -1292,6 +1368,10 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
         if (columnsToMerge.size() < 2) {
             throw new IllegalArgumentException(
                     "Cannot merge less than two columns");
+        }
+        if (columnsToMerge.contains(null)) {
+            throw new NullPointerException(
+                    "Columns to merge cannot contain null values");
         }
         if (columnsToMerge.stream()
                 .anyMatch(column -> !topLevelColumns.contains(column))) {

--- a/src/test/java/com/vaadin/ui/grid/demo/GridView.java
+++ b/src/test/java/com/vaadin/ui/grid/demo/GridView.java
@@ -154,6 +154,11 @@ public class GridView extends DemoView {
         public void setPostalCode(String postalCode) {
             this.postalCode = postalCode;
         }
+
+        @Override
+        public String toString() {
+            return String.format("%s %s", street, number);
+        }
     }
     // end-source-example
 
@@ -240,6 +245,7 @@ public class GridView extends DemoView {
         createSorting();
         createHeaderAndFooterUsingTemplates();
         createHeaderAndFooterUsingComponents();
+        createBeanGrid();
 
         addCard("Grid example model",
                 new Label("These objects are used in the examples above"));
@@ -723,6 +729,24 @@ public class GridView extends DemoView {
         grid.setId("grid-header-with-components");
         addCard("Using components", "Column header and footer using components",
                 grid);
+    }
+
+    private void createBeanGrid() {
+        // begin-source-example
+        // source-example-heading: Automatically adding columns
+        // Providing a bean-type generates columns for all of it's properties
+        Grid<Person> grid = new Grid<>(Person.class);
+        grid.setItems(getItems());
+
+        // Property-names are automatically set as keys
+        grid.getColumnByKey("id").setHidden(true);
+
+        // Columns for sub-properties can be added easily
+        grid.addColumn("address.postalCode");
+
+        // end-source-example
+        grid.setId("bean-grid");
+        addCard("Configuring Columns", "Automatically adding columns", grid);
     }
 
     private List<Person> getItems() {

--- a/src/test/java/com/vaadin/ui/grid/tests/BeanGridTest.java
+++ b/src/test/java/com/vaadin/ui/grid/tests/BeanGridTest.java
@@ -38,7 +38,8 @@ public class BeanGridTest {
 
     @Test
     public void beanGrid_columnsForPropertiesAddedWithCorrectKeys() {
-        String[] expectedKeys = new String[] { "born", "name", "friend" };
+        String[] expectedKeys = new String[] { "born", "name", "friend",
+                "grades", "items" };
         Object[] keys = grid.getColumns().stream().map(Column::getKey)
                 .toArray();
 

--- a/src/test/java/com/vaadin/ui/grid/tests/BeanGridTest.java
+++ b/src/test/java/com/vaadin/ui/grid/tests/BeanGridTest.java
@@ -17,12 +17,17 @@ package com.vaadin.ui.grid.tests;
 
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import com.vaadin.ui.grid.Grid;
 import com.vaadin.ui.grid.Grid.Column;
 
 public class BeanGridTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
     Grid<Person> grid;
 
@@ -54,25 +59,36 @@ public class BeanGridTest {
                 grid.getColumnByKey(property));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void duplicateColumnsForSameProperty_throws() {
+        expectIllegalArgumentException(
+                "Multiple columns for the same property");
         grid.addColumn("name");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void duplicateColumnsForSameSubProperty_throws() {
+        expectIllegalArgumentException(
+                "Multiple columns for the same property");
         grid.addColumn("friend.name");
         grid.addColumn("friend.name");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void addColumnForNonExistingProperty_throws() {
+        expectIllegalArgumentException("Can't resolve property name");
         grid.addColumn("foobar");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void addColumnForNonExistingSubProperty_throws() {
+        expectIllegalArgumentException("Can't resolve property name");
         grid.addColumn("friend.foobar");
+    }
+
+    private void expectIllegalArgumentException(String expectedMessage) {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage(expectedMessage);
     }
 
     @Test(expected = UnsupportedOperationException.class)

--- a/src/test/java/com/vaadin/ui/grid/tests/BeanGridTest.java
+++ b/src/test/java/com/vaadin/ui/grid/tests/BeanGridTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.ui.grid.tests;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.ui.grid.Grid;
+import com.vaadin.ui.grid.Grid.Column;
+
+public class BeanGridTest {
+
+    Grid<Person> grid;
+
+    @Before
+    public void init() {
+        grid = new Grid<>(Person.class);
+    }
+
+    @Test
+    public void beanGrid_columnsForPropertiesAddedWithCorrectKeys() {
+        String[] expectedKeys = new String[] { "born", "name", "friend" };
+        Object[] keys = grid.getColumns().stream().map(Column::getKey)
+                .toArray();
+
+        Assert.assertArrayEquals("Unexpected columns or column-keys",
+                expectedKeys, keys);
+    }
+
+    @Test
+    public void addColumnForSubProperty_columnAddedWithCorrectKey() {
+        addColumnAndTestKey("friend.name");
+        addColumnAndTestKey("friend.friend.friend");
+        addColumnAndTestKey("friend.friend.friend.born");
+    }
+
+    private void addColumnAndTestKey(String property) {
+        grid.addColumn(property);
+        Assert.assertNotNull("Column for sub-property not found by key",
+                grid.getColumnByKey(property));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void duplicateColumnsForSameProperty_throws() {
+        grid.addColumn("name");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void duplicateColumnsForSameSubProperty_throws() {
+        grid.addColumn("friend.name");
+        grid.addColumn("friend.name");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void addColumnForNonExistingProperty_throws() {
+        grid.addColumn("foobar");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void addColumnForNonExistingSubProperty_throws() {
+        grid.addColumn("friend.foobar");
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void addPropertyColumnForGridWithoutPropertySet_throws() {
+        Grid<Person> nonBeanGrid = new Grid<Person>();
+        nonBeanGrid.addColumn("friend.name");
+    }
+
+}

--- a/src/test/java/com/vaadin/ui/grid/tests/Person.java
+++ b/src/test/java/com/vaadin/ui/grid/tests/Person.java
@@ -21,6 +21,8 @@ public class Person implements Serializable {
     private String name;
     private final int born;
 
+    private Person friend;
+
     public Person(String name, int born) {
         this.name = name;
         this.born = born;
@@ -36,6 +38,14 @@ public class Person implements Serializable {
 
     public int getBorn() {
         return born;
+    }
+
+    public Person getFriend() {
+        return friend;
+    }
+
+    public void setFriend(Person friend) {
+        this.friend = friend;
     }
 
     @Override

--- a/src/test/java/com/vaadin/ui/grid/tests/Person.java
+++ b/src/test/java/com/vaadin/ui/grid/tests/Person.java
@@ -16,12 +16,17 @@
 package com.vaadin.ui.grid.tests;
 
 import java.io.Serializable;
+import java.util.List;
 
 public class Person implements Serializable {
     private String name;
     private final int born;
 
     private Person friend;
+
+    private List<String> items;
+
+    private int[] grades;
 
     public Person(String name, int born) {
         this.name = name;
@@ -46,6 +51,22 @@ public class Person implements Serializable {
 
     public void setFriend(Person friend) {
         this.friend = friend;
+    }
+
+    public List<String> getItems() {
+        return items;
+    }
+
+    public void setItems(List<String> items) {
+        this.items = items;
+    }
+
+    public int[] getGrades() {
+        return grades;
+    }
+
+    public void setGrades(int[] grades) {
+        this.grades = grades;
     }
 
     @Override


### PR DESCRIPTION
Implemented the so-called BeanGrid feature: Added a constructor for Grid that takes a bean-type as it's parameter and automatically adds columns for each of the bean's properties. Also added addColumn(String) method for easily creating columns for sub-properties.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-flow/38)
<!-- Reviewable:end -->
