### PR TITLE
Make ComponentRenderers use virtual children

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,12 @@
             <artifactId>flow-data</artifactId>
             <version>${flow.version}</version>
         </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>3.1.0</version>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- Dependencies for the demo -->
         <dependency>

--- a/src/main/java/com/vaadin/ui/grid/AbstractColumn.java
+++ b/src/main/java/com/vaadin/ui/grid/AbstractColumn.java
@@ -82,9 +82,22 @@ public class AbstractColumn<T extends AbstractColumn<T>> extends Component
     private void setupHeaderOrFooter(boolean header,
             TemplateRenderer<?> renderer, Element headerOrFooter) {
         if (renderer instanceof ComponentTemplateRenderer) {
-            GridTemplateRendererUtil.setupHeaderOrFooterComponentRenderer(this,
-                    (ComponentTemplateRenderer<?, ?>) renderer);
+            /*
+             * The ComponentTemplateRenderer requires a nodeId to work, and for
+             * that it needs the parent to be attached.
+             */
+            headerOrFooter.getNode().runWhenAttached(ui -> {
+                GridTemplateRendererUtil.setupHeaderOrFooterComponentRenderer(
+                        this, (ComponentTemplateRenderer<?, ?>) renderer);
+                setupHeaderOrFooterTemplate(header, renderer, headerOrFooter);
+            });
+        } else {
+            setupHeaderOrFooterTemplate(header, renderer, headerOrFooter);
         }
+    }
+
+    private void setupHeaderOrFooterTemplate(boolean header,
+            TemplateRenderer<?> renderer, Element headerOrFooter) {
 
         headerOrFooter.setProperty("innerHTML",
                 header ? getHeaderRendererTemplate(renderer)

--- a/src/main/java/com/vaadin/ui/grid/Grid.java
+++ b/src/main/java/com/vaadin/ui/grid/Grid.java
@@ -98,6 +98,8 @@ import elemental.json.JsonValue;
 public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
         HasSize, Focusable<Grid<T>>, SortNotifier<Grid<T>, GridSortOrder<T>> {
 
+    private static final String GRID_COMPONENT_RENDERER_TAG = "flow-grid-component-renderer";
+
     private final class UpdateQueue implements Update {
         private List<Runnable> queue = new ArrayList<>();
 
@@ -245,15 +247,20 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
 
             comparator = (a, b) -> 0;
 
+            String template;
             if (renderer instanceof ComponentTemplateRenderer) {
                 renderedComponents = new HashMap<>();
                 ComponentTemplateRenderer<? extends Component, T> componentRenderer = (ComponentTemplateRenderer<? extends Component, T>) renderer;
                 grid.setupItemComponentRenderer(this, columnId,
                         componentRenderer, renderedComponents);
+                template = componentRenderer
+                        .getTemplate(GRID_COMPONENT_RENDERER_TAG);
+            } else {
+                template = renderer.getTemplate();
             }
 
             Element contentTemplate = new Element("template")
-                    .setProperty("innerHTML", renderer.getTemplate());
+                    .setProperty("innerHTML", template);
 
             getElement().setAttribute("id", columnId)
                     .appendChild(contentTemplate);
@@ -1178,17 +1185,23 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
         if (renderer == null) {
             return;
         }
+
+        String template;
         if (renderer instanceof ComponentTemplateRenderer) {
             renderedDetailComponents = new HashMap<>();
 
             ComponentTemplateRenderer<? extends Component, T> componentRenderer = (ComponentTemplateRenderer<? extends Component, T>) renderer;
             itemDetailsDataGeneratorRegistration = setupItemComponentRenderer(
                     this, null, componentRenderer, renderedDetailComponents);
+            template = componentRenderer
+                    .getTemplate(GRID_COMPONENT_RENDERER_TAG);
+        } else {
+            template = renderer.getTemplate();
         }
 
         Element newDetailsTemplate = new Element("template")
                 .setAttribute("class", "row-details")
-                .setProperty("innerHTML", renderer.getTemplate());
+                .setProperty("innerHTML", template);
 
         detailsTemplate = newDetailsTemplate;
         getElement().appendChild(detailsTemplate);
@@ -1465,8 +1478,6 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
             ComponentTemplateRenderer<? extends Component, T> componentRenderer,
             Map<String, Component> renderedComponents) {
 
-        componentRenderer
-                .setComponentRendererTag("flow-grid-component-renderer");
         Element container = new Element("div", false);
         owner.getElement().appendVirtualChild(container);
 

--- a/src/main/resources/META-INF/resources/frontend/flow-grid-component-renderer.html
+++ b/src/main/resources/META-INF/resources/frontend/flow-grid-component-renderer.html
@@ -1,0 +1,17 @@
+<dom-module id="flow-grid-component-renderer">  
+  <script>
+  class FlowGridComponentRenderer extends FlowComponentRenderer {
+    static get is() { return 'flow-grid-component-renderer'; }
+    
+    _notifyResize(){
+      if (this.parentElement && this.parentElement.parentElement && 
+          this.parentElement.parentElement.tagName === "VAADIN-GRID"){
+            
+        let grid = this.parentElement.parentElement;
+        grid.$connector.asyncNotifyResize();
+      }
+    }
+  }
+  window.customElements.define(FlowGridComponentRenderer.is, FlowGridComponentRenderer);
+  </script> 
+</dom-module>

--- a/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -15,10 +15,10 @@ window.gridConnector = {
     
     // Used by flow-grid-component-renderer 
     grid.$connector.asyncNotifyResize = function() {
-    	grid.$connector.resizeDebouncer = Polymer.Debouncer.debounce(
-    			grid.$connector.resizeDebouncer,
-    	        Polymer.Async.animationFrame,
-    	        () => grid.notifyResize());
+      grid.$connector.resizeDebouncer = Polymer.Debouncer.debounce(
+          grid.$connector.resizeDebouncer,
+              Polymer.Async.animationFrame,
+              () => grid.notifyResize());
     }
 
     grid.$connector.doSelection = function(item, userOriginated) {

--- a/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -12,6 +12,14 @@ window.gridConnector = {
     grid.size = 0; // To avoid NaN here and there before we get proper data
 
     grid.$connector = {};
+    
+    // Used by flow-grid-component-renderer 
+    grid.$connector.asyncNotifyResize = function() {
+    	grid.$connector.resizeDebouncer = Polymer.Debouncer.debounce(
+    			grid.$connector.resizeDebouncer,
+    	        Polymer.Async.animationFrame,
+    	        () => grid.notifyResize());
+    }
 
     grid.$connector.doSelection = function(item, userOriginated) {
       if (selectionMode === 'NONE') {
@@ -102,8 +110,8 @@ window.gridConnector = {
     grid.addEventListener('sorter-changed', sorterChangeListener);
 
     const itemsUpdated = function(items) {
-      if (!items || !(items instanceof Array)) {
-        throw 'Attempted to call itemsUpdated with an invalid value';
+      if (!items || !Array.isArray(items)) {
+        throw 'Attempted to call itemsUpdated with an invalid value: ' + JSON.stringify(items);
       }
       const detailsOpenedItems = [];
       for (let i = 0; i < items.length; ++i) {
@@ -187,7 +195,7 @@ window.gridConnector = {
           }
         }
       }
-      for (let page in pagesToUpdate) {
+      for (let page of pagesToUpdate) {
         updateGridCache(page);
       }
     };

--- a/src/test/java/com/vaadin/ui/grid/tests/GridIT.java
+++ b/src/test/java/com/vaadin/ui/grid/tests/GridIT.java
@@ -73,40 +73,40 @@ public class GridIT extends TabbedComponentDemoTest {
         WebElement toggleButton = findElement(By.id("single-selection-toggle"));
         WebElement messageDiv = findElement(By.id("single-selection-message"));
 
-        toggleButton.click();
+        clickElementWithJs(toggleButton);
         Assert.assertEquals(
                 getSelectionMessage(null, GridView.items.get(0), false),
                 messageDiv.getText());
         Assert.assertTrue(isRowSelected(grid, 0));
-        toggleButton.click();
+        clickElementWithJs(toggleButton);
         Assert.assertEquals(
                 getSelectionMessage(GridView.items.get(0), null, false),
                 messageDiv.getText());
         Assert.assertFalse(isRowSelected(grid, 0));
 
         // should be the cell in the first column's second row
-        getCell(grid, "Person 2").click();
+        clickElementWithJs(getCell(grid, "Person 2"));
         Assert.assertTrue(isRowSelected(grid, 1));
         Assert.assertEquals(
                 getSelectionMessage(null, GridView.items.get(1), true),
                 messageDiv.getText());
-        getCell(grid, "Person 2").click();
+        clickElementWithJs(getCell(grid, "Person 2"));
         Assert.assertFalse(isRowSelected(grid, 1));
 
-        getCell(grid, "Person 2").click();
-        toggleButton.click();
+        clickElementWithJs(getCell(grid, "Person 2"));
+        clickElementWithJs(toggleButton);
         Assert.assertTrue(isRowSelected(grid, 0));
         Assert.assertFalse(isRowSelected(grid, 1));
         Assert.assertEquals(getSelectionMessage(GridView.items.get(1),
                 GridView.items.get(0), false), messageDiv.getText());
-        toggleButton.click();
+        clickElementWithJs(toggleButton);
         Assert.assertFalse(isRowSelected(grid, 0));
 
         // scroll to bottom
         scroll(grid, 495);
         waitUntilCellHasText(grid, "Person 499");
         // select item that is not in cache
-        toggleButton.click();
+        clickElementWithJs(toggleButton);
         // scroll back up
         scroll(grid, 0);
         waitUntilCellHasText(grid, "Person 1");
@@ -128,7 +128,7 @@ public class GridIT extends TabbedComponentDemoTest {
         WebElement selectBtn = findElement(By.id("multi-selection-button"));
         WebElement messageDiv = findElement(By.id("multi-selection-message"));
 
-        selectBtn.click();
+        clickElementWithJs(selectBtn);
         Assert.assertEquals(
                 getSelectionMessage(Collections.emptySet(),
                         GridView.items.subList(0, 5), false),
@@ -150,7 +150,7 @@ public class GridIT extends TabbedComponentDemoTest {
 
         clickCheckbox(checkboxes.get(5));
         Assert.assertTrue(isRowSelected(grid, 5));
-        selectBtn.click();
+        clickElementWithJs(selectBtn);
         assertRowsSelected(grid, 0, 5);
         Assert.assertFalse(isRowSelected(grid, 5));
     }
@@ -160,8 +160,8 @@ public class GridIT extends TabbedComponentDemoTest {
         openTabAndCheckForErrors("selection");
         WebElement grid = findElement(By.id("none-selection"));
         scrollToElement(grid);
-        grid.findElements(By.tagName("vaadin-grid-cell-content")).get(3)
-                .click();
+        clickElementWithJs(grid
+                .findElements(By.tagName("vaadin-grid-cell-content")).get(3));
         Assert.assertFalse(isRowSelected(grid, 1));
     }
 
@@ -216,10 +216,10 @@ public class GridIT extends TabbedComponentDemoTest {
         String firstCellHiddenScript = "return arguments[0].shadowRoot.querySelectorAll('td')[0].hidden;";
         Assert.assertNotEquals(true, getCommandExecutor()
                 .executeScript(firstCellHiddenScript, grid));
-        toggleIdColumnVisibility.click();
+        clickElementWithJs(toggleIdColumnVisibility);
         Assert.assertEquals(true, getCommandExecutor()
                 .executeScript(firstCellHiddenScript, grid));
-        toggleIdColumnVisibility.click();
+        clickElementWithJs(toggleIdColumnVisibility);
         Assert.assertNotEquals(true, getCommandExecutor()
                 .executeScript(firstCellHiddenScript, grid));
 
@@ -228,10 +228,10 @@ public class GridIT extends TabbedComponentDemoTest {
 
         WebElement toggleUserReordering = findElement(
                 By.id("toggle-user-reordering"));
-        toggleUserReordering.click();
+        clickElementWithJs(toggleUserReordering);
         Assert.assertEquals("true",
                 grid.getAttribute("columnReorderingAllowed"));
-        toggleUserReordering.click();
+        clickElementWithJs(toggleUserReordering);
         Assert.assertNotEquals("true",
                 grid.getAttribute("columnReorderingAllowed"));
 
@@ -256,7 +256,7 @@ public class GridIT extends TabbedComponentDemoTest {
         WebElement grid = findElement(By.id("grid-with-details-row"));
         scrollToElement(grid);
 
-        getRow(grid, 0).click();
+        clickElementWithJs(getRow(grid, 0).findElement(By.tagName("td")));
 
         WebElement detailsElement = grid
                 .findElement(By.className("custom-details"));
@@ -264,7 +264,7 @@ public class GridIT extends TabbedComponentDemoTest {
                 + "<div>Hi! My name is Person 1!</div>"
                 + "<div><vaadin-button tabindex=\"0\" role=\"button\">Update Person</vaadin-button></div>"
                 + "</div>", detailsElement.getAttribute("outerHTML"));
-        getCommandExecutor().executeScript("arguments[0].click()",
+        clickElementWithJs(
                 detailsElement.findElement(By.tagName("vaadin-button")));
 
         Assert.assertTrue(hasCell(grid, "Person 1 Updated"));
@@ -345,10 +345,10 @@ public class GridIT extends TabbedComponentDemoTest {
         WebElement grid = findElement(By.id("component-renderer"));
         scrollToElement(grid);
 
-        getRow(grid, 0).click();
+        clickElementWithJs(getRow(grid, 0).findElement(By.tagName("td")));
         assertComponentRendereredDetails(grid, 0, "Person 1");
 
-        getRow(grid, 1).click();
+        clickElementWithJs(getRow(grid, 1).findElement(By.tagName("td")));
         assertComponentRendereredDetails(grid, 1, "Person 2");
 
         WebElement idField = findElement(By.id("component-renderer-id-field"));
@@ -362,7 +362,7 @@ public class GridIT extends TabbedComponentDemoTest {
                 "SomeOtherName");
         clickElementWithJs(updateButton);
 
-        getRow(grid, 0).click();
+        clickElementWithJs(getRow(grid, 0).findElement(By.tagName("td")));
         assertComponentRendereredDetails(grid, 0, "SomeOtherName");
 
         executeScript("arguments[0].value = arguments[1];", idField, "2");
@@ -370,7 +370,7 @@ public class GridIT extends TabbedComponentDemoTest {
                 "SomeOtherName2");
         clickElementWithJs(updateButton);
 
-        getRow(grid, 1).click();
+        clickElementWithJs(getRow(grid, 1).findElement(By.tagName("td")));
         assertComponentRendereredDetails(grid, 1, "SomeOtherName2");
     }
 
@@ -387,21 +387,21 @@ public class GridIT extends TabbedComponentDemoTest {
         WebElement addressColumnSorter = getCell(grid, "Address")
                 .findElement(By.tagName("vaadin-grid-sorter"));
 
-        nameColumnSorter.click();
+        clickElementWithJs(nameColumnSorter);
         assertSortMessageEquals(QuerySortOrder.asc("name").build(), true);
-        addressColumnSorter.click();
+        clickElementWithJs(addressColumnSorter);
         assertSortMessageEquals(
                 QuerySortOrder.asc("street").thenAsc("number").build(), true);
-        addressColumnSorter.click();
+        clickElementWithJs(addressColumnSorter);
         assertSortMessageEquals(
                 QuerySortOrder.desc("street").thenDesc("number").build(), true);
-        addressColumnSorter.click();
+        clickElementWithJs(addressColumnSorter);
         assertSortMessageEquals(Collections.emptyList(), true);
 
         // enable multi sort
         clickElementWithJs(findElement(By.id("grid-multi-sort-toggle")));
-        nameColumnSorter.click();
-        ageColumnSorter.click();
+        clickElementWithJs(nameColumnSorter);
+        clickElementWithJs(ageColumnSorter);
         assertSortMessageEquals(
                 QuerySortOrder.asc("age").thenAsc("name").build(), true);
     }
@@ -580,7 +580,7 @@ public class GridIT extends TabbedComponentDemoTest {
     }
 
     private void clickCheckbox(WebElement checkbox) {
-        getInShadowRoot(checkbox, By.id("nativeCheckbox")).click();
+        clickElementWithJs(getInShadowRoot(checkbox, By.id("nativeCheckbox")));
     }
 
     @Override

--- a/src/test/java/com/vaadin/ui/grid/tests/GridIT.java
+++ b/src/test/java/com/vaadin/ui/grid/tests/GridIT.java
@@ -279,6 +279,9 @@ public class GridIT extends TabbedComponentDemoTest {
         Assert.assertEquals(0,
                 grid.findElements(By.className("custom-details")).size());
         clickElementWithJs(findElement(By.id("toggle-details-button")));
+
+        waitUntil(driver -> grid.findElements(By.className("custom-details"))
+                .size() == 1);
         Assert.assertEquals(1,
                 grid.findElements(By.className("custom-details")).size());
         Assert.assertTrue(grid.findElement(By.className("custom-details"))

--- a/src/test/java/com/vaadin/ui/grid/tests/GridIT.java
+++ b/src/test/java/com/vaadin/ui/grid/tests/GridIT.java
@@ -312,9 +312,9 @@ public class GridIT extends TabbedComponentDemoTest {
         scrollToElement(grid);
 
         Assert.assertTrue(hasComponentRendereredCell(grid,
-                "<div data-flow-renderer-item-key=\"1\">Hi, I'm Person 1!</div>"));
+                "<div>Hi, I'm Person 1!</div>"));
         Assert.assertTrue(hasComponentRendereredCell(grid,
-                "<div data-flow-renderer-item-key=\"2\">Hi, I'm Person 2!</div>"));
+                "<div>Hi, I'm Person 2!</div>"));
 
         WebElement idField = findElement(By.id("component-renderer-id-field"));
         WebElement nameField = findElement(
@@ -328,7 +328,7 @@ public class GridIT extends TabbedComponentDemoTest {
         clickElementWithJs(updateButton);
 
         waitUntil(driver -> hasComponentRendereredCell(grid,
-                "<div data-flow-renderer-item-key=\"1\">Hi, I'm SomeOtherName!</div>"));
+                "<div>Hi, I'm SomeOtherName!</div>"));
 
         executeScript("arguments[0].value = arguments[1];", idField, "2");
         executeScript("arguments[0].value = arguments[1];", nameField,
@@ -336,7 +336,7 @@ public class GridIT extends TabbedComponentDemoTest {
         clickElementWithJs(updateButton);
 
         waitUntil(driver -> hasComponentRendereredCell(grid,
-                "<div data-flow-renderer-item-key=\"2\">Hi, I'm SomeOtherName2!</div>"));
+                "<div>Hi, I'm SomeOtherName2!</div>"));
     }
 
     @Test
@@ -346,10 +346,10 @@ public class GridIT extends TabbedComponentDemoTest {
         scrollToElement(grid);
 
         getRow(grid, 0).click();
-        assertComponentRendereredDetails(grid, "1", "Person 1");
+        assertComponentRendereredDetails(grid, 0, "Person 1");
 
         getRow(grid, 1).click();
-        assertComponentRendereredDetails(grid, "2", "Person 2");
+        assertComponentRendereredDetails(grid, 1, "Person 2");
 
         WebElement idField = findElement(By.id("component-renderer-id-field"));
         WebElement nameField = findElement(
@@ -363,7 +363,7 @@ public class GridIT extends TabbedComponentDemoTest {
         clickElementWithJs(updateButton);
 
         getRow(grid, 0).click();
-        assertComponentRendereredDetails(grid, "1", "SomeOtherName");
+        assertComponentRendereredDetails(grid, 0, "SomeOtherName");
 
         executeScript("arguments[0].value = arguments[1];", idField, "2");
         executeScript("arguments[0].value = arguments[1];", nameField,
@@ -371,7 +371,7 @@ public class GridIT extends TabbedComponentDemoTest {
         clickElementWithJs(updateButton);
 
         getRow(grid, 1).click();
-        assertComponentRendereredDetails(grid, "2", "SomeOtherName2");
+        assertComponentRendereredDetails(grid, 1, "SomeOtherName2");
     }
 
     @Test
@@ -460,22 +460,22 @@ public class GridIT extends TabbedComponentDemoTest {
 
         Assert.assertTrue(
                 "There should be a cell with the renderered 'Basic Information' header",
-                hasComponentRendereredCell(grid,
-                        "<label data-flow-renderer-item-key=\"0\" title=\"Basic Information\" style=\"color: orange;\">Basic Information</label>"));
+                hasComponentRendereredHeaderCell(grid,
+                        "<label title=\"Basic Information\" style=\"color: orange;\">Basic Information</label>"));
 
         Assert.assertTrue(
                 "There should be a cell with the renderered 'Name' header",
-                hasComponentRendereredCell(grid,
-                        "<label data-flow-renderer-item-key=\"0\" title=\"Name\" style=\"color: green;\">Name</label>"));
+                hasComponentRendereredHeaderCell(grid,
+                        "<label title=\"Name\" style=\"color: green;\">Name</label>"));
 
         Assert.assertTrue(
                 "There should be a cell with the renderered 'Age' header",
-                hasComponentRendereredCell(grid,
-                        "<label data-flow-renderer-item-key=\"0\" title=\"Age\" style=\"color: blue;\">Age</label>"));
+                hasComponentRendereredHeaderCell(grid,
+                        "<label title=\"Age\" style=\"color: blue;\">Age</label>"));
 
         Assert.assertTrue("There should be a cell with the renderered footer",
-                hasComponentRendereredCell(grid,
-                        "<label data-flow-renderer-item-key=\"0\" style=\"color: red;\">Total: 499 people</label>"));
+                hasComponentRendereredHeaderCell(grid,
+                        "<label style=\"color: red;\">Total: 499 people</label>"));
     }
 
     private static String getSelectionMessage(Object oldSelection,
@@ -535,36 +535,37 @@ public class GridIT extends TabbedComponentDemoTest {
     }
 
     private boolean hasComponentRendereredCell(WebElement grid, String text) {
+        return hasComponentRendereredCell(grid, text,
+                "flow-grid-component-renderer");
+    }
+
+    private boolean hasComponentRendereredHeaderCell(WebElement grid,
+            String text) {
+        return hasComponentRendereredCell(grid, text,
+                "flow-component-renderer");
+    }
+
+    private boolean hasComponentRendereredCell(WebElement grid, String text,
+            String componentTag) {
         List<WebElement> cells = grid
                 .findElements(By.tagName("vaadin-grid-cell-content"));
 
         return cells.stream()
-                .map(cell -> cell
-                        .findElements(By.tagName("flow-component-renderer")))
+                .map(cell -> cell.findElements(By.tagName(componentTag)))
                 .filter(list -> !list.isEmpty()).map(list -> list.get(0))
                 .anyMatch(cell -> text.equals(cell.getAttribute("innerHTML")));
     }
 
-    private void assertComponentRendereredDetails(WebElement grid, String key,
+    private void assertComponentRendereredDetails(WebElement grid, int rowIndex,
             String personName) {
         waitUntil(driver -> {
             List<WebElement> elements = grid
                     .findElements(By.className("custom-details"));
-            if (elements.size() > 0) {
-                return elements.stream().anyMatch(element -> key.equals(
-                        element.getAttribute("data-flow-renderer-item-key")));
-            }
-            return false;
+            return elements.size() > rowIndex;
         });
         List<WebElement> elements = grid
                 .findElements(By.className("custom-details"));
-        WebElement element = elements.stream()
-                .filter(child -> key.equals(
-                        child.getAttribute("data-flow-renderer-item-key")))
-                .findFirst().get();
-
-        Assert.assertEquals(key,
-                element.getAttribute("data-flow-renderer-item-key"));
+        WebElement element = elements.get(rowIndex);
 
         element = element.findElement(By.tagName("vaadin-horizontal-layout"));
         Assert.assertNotNull(element);

--- a/src/test/java/com/vaadin/ui/grid/tests/GridTestPage.java
+++ b/src/test/java/com/vaadin/ui/grid/tests/GridTestPage.java
@@ -71,12 +71,13 @@ public class GridTestPage extends Div {
 
         grid.setItems(firstList);
 
-        grid.addColumn(new ComponentTemplateRenderer<>(item -> {
+        grid.addColumn(new ComponentTemplateRenderer<Label, Item>(item -> {
             Label label = new Label(item.getName());
             label.setId("grid-with-component-renderers-item-name-"
                     + item.getNumber());
             return label;
-        }));
+        }).withProperty("id", item -> "grid-with-component-renderers-item-name-"
+                + item.getNumber()));
         grid.addColumn(new ComponentTemplateRenderer<>(item -> {
             Label label = new Label(String.valueOf(item.getNumber()));
             label.setId("grid-with-component-renderers-item-number-"

--- a/src/test/java/com/vaadin/ui/grid/tests/GridTestPageIT.java
+++ b/src/test/java/com/vaadin/ui/grid/tests/GridTestPageIT.java
@@ -15,12 +15,17 @@
  */
 package com.vaadin.ui.grid.tests;
 
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
 import com.vaadin.flow.testutil.AbstractComponentIT;
@@ -64,7 +69,6 @@ public class GridTestPageIT extends AbstractComponentIT {
      * should be re-enabled.
      */
     @Test
-    @Ignore
     public void openGridWithComponents_removeItems_componentsAreRemoved() {
         WebElement grid = findElement(By.id("grid-with-component-renderers"));
         String itemIdPrefix = "grid-with-component-renderers-";
@@ -96,12 +100,20 @@ public class GridTestPageIT extends AbstractComponentIT {
     }
 
     private void assertItemIsNotPresent(WebElement grid, String itemId) {
-        try {
-            grid.findElement(By.id(itemId));
-            Assert.fail("Item with Id '" + itemId
-                    + "' is not supposed to be in the Grid");
-        } catch (NoSuchElementException ex) {
-            // expected
+        /*
+         * Grid reuses some cells over time, and items not used anymore can
+         * still be shown in the DOM tree, but are not visible in the UI.
+         * Because of that, we can't just try to find the item in the tree and
+         * assert that it's not there.
+         */
+        Map<Integer, Map<String, ?>> items = getItems(driver, grid);
+        Set<Entry<Integer, Map<String, ?>>> entrySet = items.entrySet();
+        for (Entry<Integer, Map<String, ?>> entry : entrySet) {
+            Map<String, ?> map = entry.getValue();
+            if (itemId.equals(map.get("id"))) {
+                Assert.fail("Item ID '" + itemId
+                        + "' is not supposed to be in the Grid");
+            }
         }
     }
 
@@ -118,6 +130,14 @@ public class GridTestPageIT extends AbstractComponentIT {
     private String getInnerText(WebElement element) {
         return String.valueOf(
                 executeScript("return arguments[0].innerText", element));
+    }
+
+    public static Map<Integer, Map<String, ?>> getItems(WebDriver driver,
+            WebElement element) {
+        Object result = ((JavascriptExecutor) driver)
+                .executeScript("return arguments[0]._cache.items;", element);
+
+        return (Map<Integer, Map<String, ?>>) result;
     }
 
 }

--- a/src/test/java/com/vaadin/ui/grid/tests/GridTestPageIT.java
+++ b/src/test/java/com/vaadin/ui/grid/tests/GridTestPageIT.java
@@ -51,14 +51,17 @@ public class GridTestPageIT extends AbstractComponentIT {
         WebElement grid = findElement(By.id("grid-with-component-renderers"));
         String itemIdPrefix = "grid-with-component-renderers-";
 
+        waitUntil(driver -> getItems(driver, grid).size() == 20);
         assertItemsArePresent(grid, itemIdPrefix, 0, 20);
 
         WebElement button = findElement(By.id(itemIdPrefix + "change-list"));
 
         clickElementWithJs(button);
+        waitUntil(driver -> getItems(driver, grid).size() == 10);
         assertItemsArePresent(grid, itemIdPrefix, 20, 10);
 
         clickElementWithJs(button);
+        waitUntil(driver -> getItems(driver, grid).size() == 20);
         assertItemsArePresent(grid, itemIdPrefix, 0, 20);
     }
 


### PR DESCRIPTION
This patch requires the changes made in Flow for the same feature. See https://github.com/vaadin/flow/pull/3116.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-flow/40)
<!-- Reviewable:end -->
