### PR TITLE
Fix Grid to send item details data only when the details are actually open

### DIFF
--- a/src/main/java/com/vaadin/flow/component/grid/AbstractColumn.java
+++ b/src/main/java/com/vaadin/flow/component/grid/AbstractColumn.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.component.grid;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasStyle;
+import com.vaadin.flow.data.provider.DataGenerator;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.renderer.ComponentTemplateRenderer;
 import com.vaadin.flow.renderer.TemplateRenderer;
@@ -102,10 +103,14 @@ public class AbstractColumn<T extends AbstractColumn<T>> extends Component
         headerOrFooter.setProperty("innerHTML",
                 header ? getHeaderRendererTemplate(renderer)
                         : getFooterRendererTemplate(renderer));
-        GridTemplateRendererUtil.setupTemplateRenderer(
-                (TemplateRenderer) renderer, headerOrFooter, getElement(),
-                getGrid().getDataGenerator(),
-                key -> getGrid().getDataCommunicator().getKeyMapper().get(key));
+        DataGenerator dataGenerator = GridTemplateRendererUtil
+                .setupTemplateRenderer((TemplateRenderer) renderer,
+                        headerOrFooter, getElement(),
+
+                        key -> getGrid().getDataCommunicator().getKeyMapper()
+                                .get(key));
+
+        getGrid().getDataGenerator().addDataGenerator(dataGenerator);
     }
 
     protected String getHeaderRendererTemplate(TemplateRenderer<?> renderer) {

--- a/src/main/java/com/vaadin/flow/component/grid/GridTemplateRendererUtil.java
+++ b/src/main/java/com/vaadin/flow/component/grid/GridTemplateRendererUtil.java
@@ -17,7 +17,7 @@ package com.vaadin.flow.component.grid;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
-import com.vaadin.flow.data.provider.HasDataGenerators;
+import com.vaadin.flow.data.provider.CompositeDataGenerator;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.ValueProvider;
 import com.vaadin.flow.internal.JsonSerializer;
@@ -38,18 +38,21 @@ class GridTemplateRendererUtil {
     private GridTemplateRendererUtil() {
     }
 
-    static <T> void setupTemplateRenderer(TemplateRenderer<T> renderer,
-            Element contentTemplate, Element templateDataHost,
-            HasDataGenerators<T> dataGenerators,
-            ValueProvider<String, ?> keyMapper) {
+    static <T> CompositeDataGenerator<T> setupTemplateRenderer(
+            TemplateRenderer<T> renderer, Element contentTemplate,
+            Element templateDataHost, ValueProvider<String, ?> keyMapper) {
+
+        CompositeDataGenerator<T> composite = new CompositeDataGenerator<>();
 
         renderer.getValueProviders()
-                .forEach((key, provider) -> dataGenerators.addDataGenerator(
+                .forEach((key, provider) -> composite.addDataGenerator(
                         (item, jsonObject) -> jsonObject.put(key,
                                 JsonSerializer.toJson(provider.apply(item)))));
 
         TemplateRendererUtil.registerEventHandlers(renderer, contentTemplate,
                 templateDataHost, key -> (T) keyMapper.apply(key));
+
+        return composite;
     }
 
     static <T> void setupHeaderOrFooterComponentRenderer(Component owner,

--- a/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -69,7 +69,11 @@ window.gridConnector = {
     grid._createPropertyObserver('activeItem', '__activeItemChanged', true);
 
     grid.__activeItemChangedDetails = function(newVal, oldVal) {
-      grid.detailsOpenedItems = [newVal];
+      if (newVal && !newVal.detailsOpened) {
+        grid.$server.setDetailsVisible(newVal.key);
+      } else {
+        grid.$server.setDetailsVisible(null);
+      }
     }
     grid._createPropertyObserver('activeItem', '__activeItemChangedDetails', true);
 
@@ -114,12 +118,21 @@ window.gridConnector = {
         throw 'Attempted to call itemsUpdated with an invalid value: ' + JSON.stringify(items);
       }
       const detailsOpenedItems = [];
+      let updatedSelectedItem = false;
       for (let i = 0; i < items.length; ++i) {
-        if (items[i].detailsOpened) {
-          detailsOpenedItems.push(items[i]);
+        const item = items[i];
+        if (item.detailsOpened) {
+          detailsOpenedItems.push(item);
+        }
+        if (selectedKeys[item.key]) {
+          selectedKeys[item.key] = item;
+          updatedSelectedItem = true;
         }
       }
       grid.detailsOpenedItems = detailsOpenedItems;
+      if (updatedSelectedItem) {
+        grid.selectedItems = Object.values(selectedKeys);
+      }
     }
 
     const updateGridCache = function(page) {

--- a/src/test/java/com/vaadin/flow/component/grid/demo/GridView.java
+++ b/src/test/java/com/vaadin/flow/component/grid/demo/GridView.java
@@ -59,7 +59,6 @@ import com.vaadin.flow.router.Route;
  */
 @Route("vaadin-grid")
 @HtmlImport("bower_components/vaadin-valo-theme/vaadin-grid.html")
-@HtmlImport("bower_components/vaadin-valo-theme/vaadin-button.html")
 @HtmlImport("bower_components/vaadin-valo-theme/vaadin-text-field.html")
 public class GridView extends DemoView {
 
@@ -592,10 +591,10 @@ public class GridView extends DemoView {
         grid.addColumn(Person::getAge).setHeader("Age");
 
         grid.setSelectionMode(SelectionMode.NONE);
-        grid.setItemDetailsRenderer(TemplateRenderer
-                .<Person> of("<div class='custom-details'>"
-                        + "<div>Hi! My name is [[item.name]]!</div>"
-                        + "<div><vaadin-button on-click='handleClick'>Update Person</vaadin-button></div>"
+        grid.setItemDetailsRenderer(TemplateRenderer.<Person> of(
+                "<div class='custom-details' style='border: 1px solid gray; padding: 10px; width: 100%; box-sizing: border-box;'>"
+                        + "<div>Hi! My name is <b>[[item.name]]!</b></div>"
+                        + "<div><button on-click='handleClick'>Update Person</button></div>"
                         + "</div>")
                 .withProperty("name", Person::getName)
                 .withEventHandler("handleClick", person -> {

--- a/src/test/java/com/vaadin/flow/component/grid/tests/GridIT.java
+++ b/src/test/java/com/vaadin/flow/component/grid/tests/GridIT.java
@@ -275,13 +275,11 @@ public class GridIT extends TabbedComponentDemoTest {
         Assert.assertEquals("div",
                 children.get(1).getTagName().toLowerCase(Locale.ENGLISH));
 
-        WebElement button = children.get(1)
-                .findElement(By.tagName("vaadin-button"));
+        WebElement button = children.get(1).findElement(By.tagName("button"));
 
         Assert.assertEquals("Update Person", button.getText());
 
-        clickElementWithJs(
-                detailsElement.findElement(By.tagName("vaadin-button")));
+        clickElementWithJs(detailsElement.findElement(By.tagName("button")));
 
         Assert.assertTrue(hasCell(grid, "Person 1 Updated"));
     }
@@ -302,7 +300,7 @@ public class GridIT extends TabbedComponentDemoTest {
                 grid.findElements(By.className("custom-details")).size());
         Assert.assertTrue(grid.findElement(By.className("custom-details"))
                 .getAttribute("innerHTML")
-                .contains("Hi! My name is Person 2!"));
+                .contains("Hi! My name is <b>Person 2!</b>"));
     }
 
     @Test

--- a/src/test/java/com/vaadin/flow/component/grid/tests/GridTestPage.java
+++ b/src/test/java/com/vaadin/flow/component/grid/tests/GridTestPage.java
@@ -25,6 +25,7 @@ import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Label;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.renderer.ComponentTemplateRenderer;
+import com.vaadin.flow.renderer.TemplateRenderer;
 import com.vaadin.flow.router.Route;
 
 /**
@@ -59,6 +60,8 @@ public class GridTestPage extends Div {
 
     public GridTestPage() {
         createGridWithComponentRenderers();
+        createGridWithTemplateDetailsRow();
+        createGridWithComponentDetailsRow();
     }
 
     private void createGridWithComponentRenderers() {
@@ -112,6 +115,38 @@ public class GridTestPage extends Div {
         });
         changeList.setId("grid-with-component-renderers-change-list");
         add(grid, changeList);
+    }
+
+    private void createGridWithTemplateDetailsRow() {
+        Grid<Item> grid = new Grid<>();
+
+        grid.setItems(generateItems(20, 0));
+
+        grid.addColumn(Item::getName);
+        grid.setItemDetailsRenderer(
+                TemplateRenderer.<Item> of("[[item.detailsProperty]]")
+                        .withProperty("detailsProperty",
+                                item -> "Details opened! " + item.getNumber()));
+
+        grid.setId("grid-with-template-details-row");
+        grid.setWidth("500px");
+        grid.setHeight("500px");
+        add(grid);
+    }
+
+    private void createGridWithComponentDetailsRow() {
+        Grid<Item> grid = new Grid<>();
+
+        grid.setItems(generateItems(20, 0));
+
+        grid.addColumn(Item::getName);
+        grid.setItemDetailsRenderer(new ComponentTemplateRenderer<>(
+                item -> new Label("Details opened! " + item.getNumber())));
+
+        grid.setId("grid-with-component-details-row");
+        grid.setWidth("500px");
+        grid.setHeight("500px");
+        add(grid);
     }
 
     private List<Item> generateItems(int amount, int startingIndex) {


### PR DESCRIPTION
In my tests there weren't any duplicated data as the ticket suggest - but a high load of unnecessary data sent from the server. That data is related to the item details - basically Grid was sending the data (and the components) related to item details for every item in the Grid, even when the details weren't shown.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-flow/51)
<!-- Reviewable:end -->
