### PR TITLE
Allow disabling opening item details by clicking on rows

### DIFF
--- a/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -712,6 +712,7 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
 
     private final DetailsManager detailsManager = new DetailsManager(this);
     private Element detailsTemplate;
+    private boolean detailsVisibleOnClick = true;
 
     private Map<String, Column<T>> idToColumnMap = new HashMap<>();
     private Map<String, Column<T>> keyToColumnMap = new HashMap<>();
@@ -1382,6 +1383,33 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
      */
     public void setDetailsVisible(T item, boolean visible) {
         detailsManager.setDetailsVisible(item, visible);
+    }
+
+    /**
+     * Sets whether the item details can be opened and closed by clicking the
+     * rows or not.
+     * 
+     * @param detailsVisibleOnClick
+     *            {@code true} to enable opening and closing item details by
+     *            clicking the rows, {@code false} to disable this functionality
+     * @see #setItemDetailsRenderer(TemplateRenderer)
+     */
+    public void setDetailsVisibleOnClick(boolean detailsVisibleOnClick) {
+        this.detailsVisibleOnClick = detailsVisibleOnClick;
+        getElement().callFunction("$connector.setDetailsVisibleOnClick",
+                detailsVisibleOnClick);
+    }
+
+    /**
+     * Gets whether the item details are opened and closed by clicking the rows
+     * or not.
+     * 
+     * @return {@code true} if clicking the rows opens and closes their item
+     *         details, {@code false} otherwise
+     * @see #setItemDetailsRenderer(TemplateRenderer)
+     */
+    public boolean isDetailsVisibleOnClick() {
+        return detailsVisibleOnClick;
     }
 
     /**

--- a/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -1395,9 +1395,11 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
      * @see #setItemDetailsRenderer(TemplateRenderer)
      */
     public void setDetailsVisibleOnClick(boolean detailsVisibleOnClick) {
-        this.detailsVisibleOnClick = detailsVisibleOnClick;
-        getElement().callFunction("$connector.setDetailsVisibleOnClick",
-                detailsVisibleOnClick);
+        if (this.detailsVisibleOnClick != detailsVisibleOnClick) {
+            this.detailsVisibleOnClick = detailsVisibleOnClick;
+            getElement().callFunction("$connector.setDetailsVisibleOnClick",
+                    detailsVisibleOnClick);
+        }
     }
 
     /**

--- a/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -9,6 +9,8 @@ window.gridConnector = {
     let selectedKeys = {};
     let selectionMode = 'SINGLE';
 
+    let detailsVisibleOnClick = true;
+
     grid.size = 0; // To avoid NaN here and there before we get proper data
 
     grid.$connector = {};
@@ -69,6 +71,9 @@ window.gridConnector = {
     grid._createPropertyObserver('activeItem', '__activeItemChanged', true);
 
     grid.__activeItemChangedDetails = function(newVal, oldVal) {
+      if(!detailsVisibleOnClick) {
+        return;
+      }
       if (newVal && !newVal.detailsOpened) {
         grid.$server.setDetailsVisible(newVal.key);
       } else {
@@ -76,6 +81,10 @@ window.gridConnector = {
       }
     }
     grid._createPropertyObserver('activeItem', '__activeItemChangedDetails', true);
+
+    grid.$connector.setDetailsVisibleOnClick = function(visibleOnClick) {
+      detailsVisibleOnClick = visibleOnClick;
+    };
 
     grid.dataProvider = function(params, callback) {
       if (params.pageSize != grid.pageSize) {

--- a/src/test/java/com/vaadin/flow/component/grid/demo/GridView.java
+++ b/src/test/java/com/vaadin/flow/component/grid/demo/GridView.java
@@ -623,22 +623,11 @@ public class GridView extends DemoView {
         // Disable the default way of opening item details:
         grid.setDetailsVisibleOnClick(false);
 
-        grid.setSelectionMode(SelectionMode.SINGLE);
-
-        NativeButton toggleDetails = new NativeButton(
-                "Toggle details open for selected row");
-        toggleDetails.addClickListener(event -> {
-            Person selected = grid.asSingleSelect().getValue();
-            if (selected != null) {
-                grid.setDetailsVisible(selected,
-                        !grid.isDetailsVisible(selected));
-            }
-        });
+        grid.addColumn(new ButtonRenderer<>("Toggle details open", item -> grid
+                .setDetailsVisible(item, !grid.isDetailsVisible(item))));
         // end-source-example
         grid.setId("grid-with-details-row-2");
-        toggleDetails.setId("toggle-details-button");
-        addCard("Item details", "Open details programmatically", grid,
-                toggleDetails);
+        addCard("Item details", "Open details programmatically", grid);
     }
 
     private void createColumnGroup() {

--- a/src/test/java/com/vaadin/flow/component/grid/demo/GridView.java
+++ b/src/test/java/com/vaadin/flow/component/grid/demo/GridView.java
@@ -288,9 +288,10 @@ public class GridView extends DemoView {
         createColumnApiExample();
         createBasicRenderers();
         createColumnTemplate();
-        createDetailsRow();
         createColumnGroup();
         createColumnComponentTemplateRenderer();
+        createItemDetails();
+        createItemDetailsOpenedProgrammatically();
         createSorting();
         createHeaderAndFooterUsingTemplates();
         createHeaderAndFooterUsingComponents();
@@ -580,9 +581,9 @@ public class GridView extends DemoView {
                         freezeIdColumn, merge));
     }
 
-    private void createDetailsRow() {
+    private Grid<Person> createGridWithDetails() {
         // begin-source-example
-        // source-example-heading: Grid with a details row
+        // source-example-heading: Grid with item details
         Grid<Person> grid = new Grid<>();
         List<Person> people = createItems();
         grid.setItems(people);
@@ -591,6 +592,9 @@ public class GridView extends DemoView {
         grid.addColumn(Person::getAge).setHeader("Age");
 
         grid.setSelectionMode(SelectionMode.NONE);
+
+        // You can use any renderer for the item details. By default, the
+        // details are opened and closed by clicking the rows.
         grid.setItemDetailsRenderer(TemplateRenderer.<Person> of(
                 "<div class='custom-details' style='border: 1px solid gray; padding: 10px; width: 100%; box-sizing: border-box;'>"
                         + "<div>Hi! My name is <b>[[item.name]]!</b></div>"
@@ -601,16 +605,39 @@ public class GridView extends DemoView {
                     person.setName(person.getName() + " Updated");
                     grid.getDataProvider().refreshItem(person);
                 }));
+        // end-source-example
+        return grid;
+    }
+
+    private void createItemDetails() {
+        Grid<Person> grid = createGridWithDetails();
+        grid.setId("grid-with-details-row");
+        addCard("Item details", "Grid with item details", grid);
+    }
+
+    private void createItemDetailsOpenedProgrammatically() {
+        Grid<Person> grid = createGridWithDetails();
+
+        // begin-source-example
+        // source-example-heading: Open details programmatically
+        // Disable the default way of opening item details:
+        grid.setDetailsVisibleOnClick(false);
+
+        grid.setSelectionMode(SelectionMode.SINGLE);
 
         NativeButton toggleDetails = new NativeButton(
-                "Toggle details open for second row");
-        toggleDetails
-                .addClickListener(event -> grid.setDetailsVisible(people.get(1),
-                        !grid.isDetailsVisible(people.get(1))));
+                "Toggle details open for selected row");
+        toggleDetails.addClickListener(event -> {
+            Person selected = grid.asSingleSelect().getValue();
+            if (selected != null) {
+                grid.setDetailsVisible(selected,
+                        !grid.isDetailsVisible(selected));
+            }
+        });
         // end-source-example
-        grid.setId("grid-with-details-row");
+        grid.setId("grid-with-details-row-2");
         toggleDetails.setId("toggle-details-button");
-        addCard("Using templates", "Grid with a details row", grid,
+        addCard("Item details", "Open details programmatically", grid,
                 toggleDetails);
     }
 

--- a/src/test/java/com/vaadin/flow/component/grid/tests/GridIT.java
+++ b/src/test/java/com/vaadin/flow/component/grid/tests/GridIT.java
@@ -254,7 +254,7 @@ public class GridIT extends TabbedComponentDemoTest {
 
     @Test
     public void gridDetailsRowTests() {
-        openTabAndCheckForErrors("using-templates");
+        openTabAndCheckForErrors("item-details");
         WebElement grid = findElement(By.id("grid-with-details-row"));
         scrollToElement(grid);
 
@@ -286,21 +286,42 @@ public class GridIT extends TabbedComponentDemoTest {
 
     @Test
     public void gridDetailsRowServerAPI() {
-        openTabAndCheckForErrors("using-templates");
-        WebElement grid = findElement(By.id("grid-with-details-row"));
+        openTabAndCheckForErrors("item-details");
+        WebElement grid = findElement(By.id("grid-with-details-row-2"));
         scrollToElement(grid);
 
-        Assert.assertEquals(0,
-                grid.findElements(By.className("custom-details")).size());
-        clickElementWithJs(findElement(By.id("toggle-details-button")));
+        clickElementWithJs(getRow(grid, 0).findElement(By.tagName("td")));
 
-        waitUntil(driver -> grid.findElements(By.className("custom-details"))
-                .size() == 1);
-        Assert.assertEquals(1,
-                grid.findElements(By.className("custom-details")).size());
+        List<WebElement> toggleDetailsButtons = grid
+                .findElements(By.tagName("button"));
+
+        clickElementWithJs(getRow(grid, 0).findElement(By.tagName("td")));
+        assertAmountOfOpenDetails(grid, 0);
+
+        clickElementWithJs(toggleDetailsButtons.get(1));
+        assertAmountOfOpenDetails(grid, 1);
+
         Assert.assertTrue(grid.findElement(By.className("custom-details"))
                 .getAttribute("innerHTML")
                 .contains("Hi! My name is <b>Person 2!</b>"));
+
+        clickElementWithJs(toggleDetailsButtons.get(3));
+        assertAmountOfOpenDetails(grid, 2);
+
+        clickElementWithJs(toggleDetailsButtons.get(1));
+        Assert.assertFalse(
+                "Details should be closed after clicking the button again",
+                grid.findElement(By.className("custom-details"))
+                        .getAttribute("innerHTML")
+                        .contains("Hi! My name is <b>Person 2!</b>"));
+    }
+
+    private void assertAmountOfOpenDetails(WebElement grid,
+            int expectedAmount) {
+        waitUntil(driver -> grid.findElements(By.className("custom-details"))
+                .size() == expectedAmount);
+        Assert.assertEquals(expectedAmount,
+                grid.findElements(By.className("custom-details")).size());
     }
 
     @Test


### PR DESCRIPTION
Add getter and setter for `detailsVisibleOnClick`, which has a default value of `true`. The demo for details row is separated to it's own tab and there are now two demos: the first one demonstrates only the default functionality with details opening by clicking on rows, and the second one disables this and opens details with the server-side API. Also, changed mentions of "details row" to "item details" in the demo, since this is the API naming we're using.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-flow/53)
<!-- Reviewable:end -->
