### PR TITLE
Fix multiselection bug

### DIFF
--- a/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -94,10 +94,10 @@ import elemental.json.JsonValue;
  *
  */
 @Tag("vaadin-grid")
-@HtmlImport("frontend://bower_components/vaadin-grid/vaadin-grid.html")
+@HtmlImport("frontend://bower_components/vaadin-grid/src/vaadin-grid.html")
 @HtmlImport("frontend://bower_components/vaadin-grid/vaadin-grid-column.html")
 @HtmlImport("frontend://bower_components/vaadin-grid/vaadin-grid-sorter.html")
-@HtmlImport("frontend://bower_components/vaadin-checkbox/vaadin-checkbox.html")
+@HtmlImport("frontend://bower_components/vaadin-checkbox/src/vaadin-checkbox.html")
 @HtmlImport("frontend://flow-grid-component-renderer.html")
 @JavaScript("frontend://gridConnector.js")
 public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,

--- a/src/main/resources/META-INF/resources/frontend/vaadin-grid-flow-selection-column.html
+++ b/src/main/resources/META-INF/resources/frontend/vaadin-grid-flow-selection-column.html
@@ -108,6 +108,7 @@
 
       _onSelectClick(e) {
         e.target.checked ? this._grid.$connector.doDeselection(e.model.item, true) : this._grid.$connector.doSelection(e.model.item, true);
+        e.target.checked = !e.target.checked;
       }
 
       _onSelectAllClick(e) {

--- a/src/test/java/com/vaadin/flow/component/grid/demo/GridView.java
+++ b/src/test/java/com/vaadin/flow/component/grid/demo/GridView.java
@@ -58,8 +58,8 @@ import com.vaadin.flow.router.Route;
  * View for {@link Grid} demo.
  */
 @Route("vaadin-grid")
-@HtmlImport("bower_components/vaadin-valo-theme/vaadin-grid.html")
-@HtmlImport("bower_components/vaadin-valo-theme/vaadin-text-field.html")
+@HtmlImport("frontend://bower_components/vaadin-grid/theme/lumo/vaadin-grid.html")
+@HtmlImport("frontend://bower_components/vaadin-text-field/theme/lumo/vaadin-text-field.html")
 public class GridView extends DemoView {
 
     public static List<Person> items = new ArrayList<>();

--- a/src/test/java/com/vaadin/flow/component/grid/it/GridMultiSelectionColumnPageIT.java
+++ b/src/test/java/com/vaadin/flow/component/grid/it/GridMultiSelectionColumnPageIT.java
@@ -53,7 +53,7 @@ public class GridMultiSelectionColumnPageIT extends AbstractComponentIT {
         WebElement selectCheckbox = grid
                 .findElements(By.tagName("vaadin-checkbox")).get(5);
         Assert.assertEquals("true", selectCheckbox.getAttribute("checked"));
-        getInShadowRoot(selectCheckbox, By.id("nativeCheckbox")).click();
+        selectCheckbox.click();
         Assert.assertNull(selectCheckbox.getAttribute("checked"));
         Assert.assertNull(selectAllCheckbox.getAttribute("checked"));
         Assert.assertEquals(

--- a/src/test/java/com/vaadin/flow/component/grid/it/GridViewIT.java
+++ b/src/test/java/com/vaadin/flow/component/grid/it/GridViewIT.java
@@ -142,15 +142,15 @@ public class GridViewIT extends TabbedComponentDemoTest {
                 .filter(element -> "Select Row"
                         .equals(element.getAttribute("aria-label")))
                 .collect(Collectors.toList());
-        clickCheckbox(checkboxes.get(0));
-        clickCheckbox(checkboxes.get(1));
+        checkboxes.get(0).click();
+        checkboxes.get(1).click();
         Assert.assertEquals(
                 getSelectionMessage(GridView.items.subList(1, 5),
                         GridView.items.subList(2, 5), true),
                 messageDiv.getText());
         assertRowsSelected(grid, 2, 5);
 
-        clickCheckbox(checkboxes.get(5));
+        checkboxes.get(5).click();
         Assert.assertTrue(isRowSelected(grid, 5));
         clickElementWithJs(selectBtn);
         assertRowsSelected(grid, 0, 5);
@@ -677,10 +677,6 @@ public class GridViewIT extends TabbedComponentDemoTest {
 
     private List<WebElement> getCells(WebElement grid) {
         return grid.findElements(By.tagName("vaadin-grid-cell-content"));
-    }
-
-    private void clickCheckbox(WebElement checkbox) {
-        clickElementWithJs(getInShadowRoot(checkbox, By.id("nativeCheckbox")));
     }
 
     @Override


### PR DESCRIPTION
There was a bug with grid in multiselection mode: The first click on a checkbox in the selection column would do the selection but the checkbox would stay unchecked. The second click would make the checkbox checked, but wouldn't change the selection. The same with unselecting.
This patch fixes the inconsistent state between checkboxes and selected items.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-flow/61)
<!-- Reviewable:end -->
