### PR TITLE
Reuse templates for header, footer and details

### DIFF
--- a/src/main/java/com/vaadin/flow/component/grid/AbstractColumn.java
+++ b/src/main/java/com/vaadin/flow/component/grid/AbstractColumn.java
@@ -22,6 +22,7 @@ import com.vaadin.flow.data.renderer.ComponentRenderer;
 import com.vaadin.flow.data.renderer.Renderer;
 import com.vaadin.flow.data.renderer.Rendering;
 import com.vaadin.flow.data.renderer.TemplateRenderer;
+import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.internal.HtmlUtils;
 
 /**
@@ -36,6 +37,8 @@ public class AbstractColumn<T extends AbstractColumn<T>> extends Component
         implements ColumnBase<T>, HasStyle {
 
     protected final Grid<?> grid;
+    protected Element headerTemplate;
+    protected Element footerTemplate;
 
     /**
      * Base constructor with the destination Grid.
@@ -105,17 +108,22 @@ public class AbstractColumn<T extends AbstractColumn<T>> extends Component
     }
 
     protected Rendering<?> renderHeader(Renderer<?> renderer) {
-        return renderAndSetClass(renderer, "header");
+        if (headerTemplate != null) {
+            return renderer.render(getElement(), null, headerTemplate);
+        }
+        Rendering<?> rendering = renderer.render(getElement(), null);
+        headerTemplate = rendering.getTemplateElement();
+        headerTemplate.setAttribute("class", "header");
+        return rendering;
     }
 
     protected Rendering<?> renderFooter(Renderer<?> renderer) {
-        return renderAndSetClass(renderer, "footer");
-    }
-
-    private Rendering<?> renderAndSetClass(Renderer<?> renderer,
-            String className) {
+        if (footerTemplate != null) {
+            return renderer.render(getElement(), null, headerTemplate);
+        }
         Rendering<?> rendering = renderer.render(getElement(), null);
-        rendering.getTemplateElement().get().setAttribute("class", className);
+        footerTemplate = rendering.getTemplateElement();
+        footerTemplate.setAttribute("class", "footer");
         return rendering;
     }
 }

--- a/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -538,7 +538,7 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
         protected Rendering<?> renderHeader(Renderer<?> renderer) {
             Rendering<?> rendering = super.renderHeader(renderer);
 
-            headerTemplate = rendering.getTemplateElement().get();
+            headerTemplate = rendering.getTemplateElement();
             rawHeaderTemplate = headerTemplate.getProperty("innerHTML");
             if (isSortable()) {
                 headerTemplate.setProperty("innerHTML", addGridSorter());
@@ -1230,9 +1230,6 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
      *            {@code null} to remove the current renderer
      */
     public void setItemDetailsRenderer(Renderer<T> renderer) {
-        if (detailsTemplate != null) {
-            getElement().removeChild(detailsTemplate);
-        }
         detailsManager.destroyAllData();
         if (renderer == null) {
             return;
@@ -1243,17 +1240,23 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
                     .setComponentRendererTag(GRID_COMPONENT_RENDERER_TAG);
         }
 
-        Rendering<T> rendering = renderer.render(getElement(),
-                (KeyMapper<T>) getDataCommunicator().getKeyMapper());
+        Rendering<T> rendering;
+        if (detailsTemplate == null) {
+            rendering = renderer.render(getElement(),
+                    (KeyMapper<T>) getDataCommunicator().getKeyMapper());
+            detailsTemplate = rendering.getTemplateElement();
+            detailsTemplate.setAttribute("class", "row-details");
+        } else {
+            rendering = renderer.render(getElement(),
+                    (KeyMapper<T>) getDataCommunicator().getKeyMapper(),
+                    detailsTemplate);
+        }
+
         Optional<DataGenerator<T>> dataGenerator = rendering.getDataGenerator();
 
         if (dataGenerator.isPresent()) {
             itemDetailsDataGenerator = dataGenerator.get();
         }
-
-        Element newDetailsTemplate = rendering.getTemplateElement().get();
-        newDetailsTemplate.setAttribute("class", "row-details");
-        detailsTemplate = newDetailsTemplate;
     }
 
     /**


### PR DESCRIPTION
Instead of always creating new `<template>` elements, reuse the old one if such is already created.

In addition to increasing performance, this also allows changing the header and footer after once set, because previously it would just have added new templates next to the existing ones, and the existing template would still have been used for the header/footer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-flow/92)
<!-- Reviewable:end -->
