### PR TITLE
Fix Grid state when reattaching it to the tree

### DIFF
--- a/src/main/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModel.java
+++ b/src/main/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModel.java
@@ -15,11 +15,9 @@
  */
 package com.vaadin.flow.component.grid;
 
-import java.io.Serializable;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -35,14 +33,13 @@ import com.vaadin.flow.data.selection.SelectionEvent;
 import com.vaadin.flow.data.selection.SelectionListener;
 import com.vaadin.flow.shared.Registration;
 
-import elemental.json.Json;
 import elemental.json.JsonObject;
 
 /**
  * Abstract implementation of a GridMultiSelectionModel.
  *
  * @param <T>
- *         the grid type
+ *            the grid type
  * @author Vaadin Ltd.
  */
 public abstract class AbstractGridMultiSelectionModel<T>
@@ -56,8 +53,8 @@ public abstract class AbstractGridMultiSelectionModel<T>
      * Constructor for passing a reference of the grid to this implementation.
      *
      * @param grid
-     *         reference to the grid for which this selection model is
-     *         created
+     *            reference to the grid for which this selection model is
+     *            created
      */
     public AbstractGridMultiSelectionModel(Grid<T> grid) {
         super(grid);
@@ -147,7 +144,8 @@ public abstract class AbstractGridMultiSelectionModel<T>
 
     @Override
     public void selectAll() {
-        updateSelection(getGrid().getDataCommunicator().getDataProvider()
+        updateSelection(
+                getGrid().getDataCommunicator().getDataProvider()
                         .fetch(new Query<>()).collect(Collectors.toSet()),
                 Collections.emptySet());
         selectionColumn.setSelectAllCheckboxState(true);
@@ -265,21 +263,17 @@ public abstract class AbstractGridMultiSelectionModel<T>
         }
     }
 
-    @Override
-    public void destroyAllData() {
-        deselectAll();
-    }
-
     /**
      * Method for handling the firing of selection events.
      *
      * @param event
-     *         the selection event to fire
+     *            the selection event to fire
      */
     protected abstract void fireSelectionEvent(SelectionEvent<T> event);
 
     private void clientSelectAll() {
-        doUpdateSelection(getGrid().getDataCommunicator().getDataProvider()
+        doUpdateSelection(
+                getGrid().getDataCommunicator().getDataProvider()
                         .fetch(new Query<>()).collect(Collectors.toSet()),
                 Collections.emptySet(), true);
         selectionColumn.setSelectAllCheckboxState(true);
@@ -311,8 +305,8 @@ public abstract class AbstractGridMultiSelectionModel<T>
     private void doUpdateSelection(Set<T> addedItems, Set<T> removedItems,
             boolean userOriginated) {
         addedItems.removeIf(removedItems::remove);
-        if (selected.containsAll(addedItems) && Collections
-                .disjoint(selected, removedItems)) {
+        if (selected.containsAll(addedItems)
+                && Collections.disjoint(selected, removedItems)) {
             return;
         }
         Set<T> oldSelection = new LinkedHashSet<>(selected);
@@ -322,28 +316,20 @@ public abstract class AbstractGridMultiSelectionModel<T>
         sendAddedItems(addedItems);
         sendRemovedItems(removedItems);
 
-        fireSelectionEvent(
-                new MultiSelectionEvent<>(getGrid(), getGrid().asMultiSelect(),
-                        oldSelection, userOriginated));
+        fireSelectionEvent(new MultiSelectionEvent<>(getGrid(),
+                getGrid().asMultiSelect(), oldSelection, userOriginated));
         if (!removedItems.isEmpty()) {
             selectionColumn.setSelectAllCheckboxState(false);
         }
     }
 
     private void sendAddedItems(Set<T> addedItems) {
-        if(addedItems.isEmpty()) {
+        if (addedItems.isEmpty()) {
             return;
         }
 
         addedItems.forEach(getGrid().getDataCommunicator()::refresh);
-
-        Serializable[] values = new Serializable[addedItems.size() + 1];
-        List<Serializable> collect = addedItems.stream()
-                .map(item -> generateJson(item))
-                .map(item -> (Serializable) item).collect(Collectors.toList());
-        collect.add(1, false);
-        collect.toArray(values);
-        getGrid().getElement().callFunction("$connector.doSelection", values);
+        getGrid().doClientSideDesselection(addedItems);
     }
 
     private void sendRemovedItems(Set<T> removedItems) {
@@ -352,21 +338,6 @@ public abstract class AbstractGridMultiSelectionModel<T>
         }
 
         removedItems.forEach(getGrid().getDataCommunicator()::refresh);
-
-        Serializable[] values = new Serializable[removedItems.size() + 1];
-        List<Serializable> collect = removedItems.stream()
-                .map(item -> generateJson(item))
-                .map(item -> (Serializable) item).collect(Collectors.toList());
-        collect.add(1, false);
-        collect.toArray(values);
-        getGrid().getElement().callFunction("$connector.doDeselection", values);
-    }
-
-    private JsonObject generateJson(T item) {
-        JsonObject json = Json.createObject();
-        json.put("key",
-                getGrid().getDataCommunicator().getKeyMapper().key(item));
-
-        return json;
+        getGrid().doClientSideDesselection(removedItems);
     }
 }

--- a/src/main/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModel.java
+++ b/src/main/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModel.java
@@ -329,7 +329,7 @@ public abstract class AbstractGridMultiSelectionModel<T>
         }
 
         addedItems.forEach(getGrid().getDataCommunicator()::refresh);
-        getGrid().doClientSideDesselection(addedItems);
+        getGrid().doClientSideSelection(addedItems);
     }
 
     private void sendRemovedItems(Set<T> removedItems) {
@@ -338,6 +338,6 @@ public abstract class AbstractGridMultiSelectionModel<T>
         }
 
         removedItems.forEach(getGrid().getDataCommunicator()::refresh);
-        getGrid().doClientSideDesselection(removedItems);
+        getGrid().doClientSideDeselection(removedItems);
     }
 }

--- a/src/main/java/com/vaadin/flow/component/grid/AbstractGridSingleSelectionModel.java
+++ b/src/main/java/com/vaadin/flow/component/grid/AbstractGridSingleSelectionModel.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.grid;
 
+import java.util.Collections;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -25,10 +26,8 @@ import com.vaadin.flow.data.selection.SelectionListener;
 import com.vaadin.flow.data.selection.SingleSelect;
 import com.vaadin.flow.data.selection.SingleSelectionEvent;
 import com.vaadin.flow.data.selection.SingleSelectionListener;
-import com.vaadin.flow.internal.JsonSerializer;
 import com.vaadin.flow.shared.Registration;
 
-import elemental.json.Json;
 import elemental.json.JsonObject;
 
 /**
@@ -72,15 +71,11 @@ public abstract class AbstractGridSingleSelectionModel<T> extends
         T oldItem = selectedItem;
         doSelect(item, false);
 
-        JsonObject json = Json.createObject();
-        json.put("key", getGrid().getDataCommunicator().getKeyMapper().key(item));
-
-        getGrid().getElement().callFunction("$connector.doSelection",
-                json, false);
-        if(oldItem != null) {
+        getGrid().doClientSideSelection(Collections.singleton(item));
+        if (oldItem != null) {
             getGrid().getDataCommunicator().refresh(oldItem);
         }
-        if(item != null) {
+        if (item != null) {
             getGrid().getDataCommunicator().refresh(item);
         }
     }
@@ -168,11 +163,6 @@ public abstract class AbstractGridSingleSelectionModel<T> extends
         if (isSelected(item)) {
             jsonObject.put("selected", true);
         }
-    }
-
-    @Override
-    public void destroyAllData() {
-        deselectAll();
     }
 
     @Override

--- a/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -1387,7 +1387,7 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
     /**
      * Gets a {@link Column} of this grid by its key.
      *
-     * @see Column#setKey()
+     * @see Column#setKey(String)
      *
      * @param columnKey
      *            the identifier key of the column to get
@@ -1480,7 +1480,7 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
      * @param detailsVisibleOnClick
      *            {@code true} to enable opening and closing item details by
      *            clicking the rows, {@code false} to disable this functionality
-     * @see #setItemDetailsRenderer(TemplateRenderer)
+     * @see #setItemDetailsRenderer(Renderer)
      */
     public void setDetailsVisibleOnClick(boolean detailsVisibleOnClick) {
         if (this.detailsVisibleOnClick != detailsVisibleOnClick) {
@@ -1496,7 +1496,7 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
      * 
      * @return {@code true} if clicking the rows opens and closes their item
      *         details, {@code false} otherwise
-     * @see #setItemDetailsRenderer(TemplateRenderer)
+     * @see #setItemDetailsRenderer(Renderer)
      */
     public boolean isDetailsVisibleOnClick() {
         return detailsVisibleOnClick;
@@ -1530,7 +1530,7 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
      *            client-side, {@code false} to disable
      */
     public void setMultiSort(boolean multiSort) {
-        getElement().setProperty("multiSort", multiSort);
+        getElement().setAttribute("multi-sort", multiSort);
     }
 
     /**
@@ -1542,7 +1542,8 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
      *         {@code false} otherwise
      */
     public boolean isMultiSort() {
-        return getElement().getProperty("multiSort", false);
+        String multiSort = getElement().getAttribute("multi-sort");
+        return multiSort == null ? false : Boolean.valueOf(multiSort);
     }
 
     private List<Column<T>> fetchChildColumns(ColumnGroup columnGroup) {

--- a/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -42,7 +42,6 @@ import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.Synchronize;
 import com.vaadin.flow.component.Tag;
-import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.HtmlImport;
 import com.vaadin.flow.component.dependency.JavaScript;
 import com.vaadin.flow.data.binder.BeanPropertySet;
@@ -765,7 +764,8 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
      *            the page size. Must be greater than zero.
      */
     public Grid(int pageSize) {
-        getElement().getNode().runWhenAttached(this::initConnector);
+        getElement().getNode().runWhenAttached(
+                ui -> ui.beforeClientResponse(this, this::initConnector));
         setPageSize(pageSize);
         setSelectionModel(SelectionMode.SINGLE.createModel(this),
                 SelectionMode.SINGLE);
@@ -781,14 +781,14 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
         if (context.isClientSideInitialized()) {
             return;
         }
-        initConnector(context.getUI());
+        initConnector(context);
         updateSelectionModeOnClient();
         getDataCommunicator().reset();
     }
 
-    private void initConnector(UI ui) {
-        ui.getPage().executeJavaScript("window.gridConnector.initLazy($0)",
-                getElement());
+    private void initConnector(ExecutionContext context) {
+        context.getUI().getPage().executeJavaScript(
+                "window.gridConnector.initLazy($0)", getElement());
     }
 
     /**

--- a/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -42,6 +42,7 @@ import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.Synchronize;
 import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.HtmlImport;
 import com.vaadin.flow.component.dependency.JavaScript;
 import com.vaadin.flow.data.binder.BeanPropertySet;
@@ -82,6 +83,7 @@ import com.vaadin.flow.internal.JsonSerializer;
 import com.vaadin.flow.internal.JsonUtils;
 import com.vaadin.flow.shared.Registration;
 
+import elemental.json.Json;
 import elemental.json.JsonArray;
 import elemental.json.JsonObject;
 import elemental.json.JsonValue;
@@ -728,6 +730,7 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
     private int nextColumnId = 0;
 
     private GridSelectionModel<T> selectionModel;
+    private SelectionMode selectionMode;
 
     private final DetailsManager detailsManager = new DetailsManager(this);
     private Element detailsTemplate;
@@ -761,13 +764,27 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
      *            the page size. Must be greater than zero.
      */
     public Grid(int pageSize) {
+        getElement().addSynchronizedProperty("$connector");
         setPageSize(pageSize);
         setSelectionModel(SelectionMode.SINGLE.createModel(this),
                 SelectionMode.SINGLE);
 
-        getElement().getNode()
-                .runWhenAttached(ui -> ui.getPage().executeJavaScript(
-                        "window.gridConnector.initLazy($0)", getElement()));
+        getElement().addAttachListener(event -> getElement().getNode()
+                .runWhenAttached(this::initConnector));
+    }
+
+    private void initConnector(UI ui) {
+        ui.getPage().executeJavaScript("window.gridConnector.initLazy($0)",
+                getElement());
+        ui.beforeClientResponse(this, context -> {
+            // If Grid was detached and reattached, there's no need to reset
+            // everything
+            if (context.wasAttached()) {
+                return;
+            }
+            updateSelectionModeOnClient();
+            getDataCommunicator().reset();
+        });
     }
 
     /**
@@ -982,6 +999,7 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
     @Override
     public void setDataProvider(DataProvider<T, ?> dataProvider) {
         Objects.requireNonNull(dataProvider, "data provider cannot be null");
+        deselectAll();
         getDataCommunicator().setDataProvider(dataProvider, null);
     }
 
@@ -1085,6 +1103,11 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
             ((AbstractGridExtension<?>) selectionModel).remove();
         }
         selectionModel = model;
+        this.selectionMode = selectionMode;
+        updateSelectionModeOnClient();
+    }
+
+    private void updateSelectionModeOnClient() {
         getElement().callFunction("$connector.setSelectionMode",
                 selectionMode.name());
     }
@@ -1204,6 +1227,33 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
      */
     public void deselectAll() {
         getSelectionModel().deselectAll();
+    }
+
+    void doClientSideSelection(Set<T> items) {
+        callSelectionFunctionForItems("doSelection", items);
+    }
+
+    void doClientSideDesselection(Set<T> items) {
+        callSelectionFunctionForItems("doDeselection", items);
+    }
+
+    private void callSelectionFunctionForItems(String function, Set<T> items) {
+        if (items.isEmpty()) {
+            return;
+        }
+        Serializable[] values = new Serializable[items.size() + 1];
+        List<Serializable> collect = items.stream()
+                .map(item -> generateJsonForSelection(item))
+                .map(item -> (Serializable) item).collect(Collectors.toList());
+        collect.add(1, false);
+        collect.toArray(values);
+        getElement().callFunction("$connector." + function, values);
+    }
+
+    private JsonObject generateJsonForSelection(T item) {
+        JsonObject json = Json.createObject();
+        json.put("key", getDataCommunicator().getKeyMapper().key(item));
+        return json;
     }
 
     /**

--- a/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -1,5 +1,10 @@
 window.gridConnector = {
   initLazy: function(grid) {
+    
+    // Check whether the connector was already initialized for the grid
+    if (grid.$connector){
+      return;
+    }
     const extraPageBuffer = 2;
     const pageCallbacks = {};
     const cache = {};

--- a/src/test/java/com/vaadin/flow/component/grid/it/GridTestPage.java
+++ b/src/test/java/com/vaadin/flow/component/grid/it/GridTestPage.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import com.vaadin.flow.component.HasComponents;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.grid.Grid.Column;
 import com.vaadin.flow.component.html.Div;
@@ -28,7 +29,8 @@ import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.data.renderer.ComponentRenderer;
 import com.vaadin.flow.data.renderer.TemplateRenderer;
 import com.vaadin.flow.router.Route;
-import com.vaadin.flow.theme.NoTheme;
+import com.vaadin.flow.theme.Theme;
+import com.vaadin.flow.theme.lumo.Lumo;
 
 /**
  * Page created for testing purposes. Not suitable for demos.
@@ -37,7 +39,7 @@ import com.vaadin.flow.theme.NoTheme;
  *
  */
 @Route("vaadin-grid-test")
-@NoTheme
+@Theme(Lumo.class)
 public class GridTestPage extends Div {
 
     private static class Item implements Serializable {
@@ -66,6 +68,7 @@ public class GridTestPage extends Div {
         createGridWithTemplateDetailsRow();
         createGridWithComponentDetailsRow();
         createGridWithRemovableColumns();
+        createDetachableGrid();
     }
 
     private void createGridWithComponentRenderers() {
@@ -176,6 +179,39 @@ public class GridTestPage extends Div {
         removeNameColumn.setId("remove-name-column-button");
         add(grid);
         add(removeNameColumn);
+    }
+
+    private void createDetachableGrid() {
+        Div container1 = new Div(new Label("Container 1"));
+        container1.setId("detachable-grid-container-1");
+        Div container2 = new Div(new Label("Container 2"));
+        container2.setId("detachable-grid-container-2");
+
+        Grid<Item> grid = new Grid<>();
+        grid.setId("detachable-grid");
+
+        grid.setItems(generateItems(20, 0));
+        grid.addColumn(Item::getName);
+        container1.add(grid);
+        add(container1);
+        NativeButton detach = new NativeButton("Detach grid",
+                e -> grid.getParent().ifPresent(
+                        parent -> ((HasComponents) parent).remove(grid)));
+        detach.setId("detachable-grid-detach");
+        NativeButton attach1 = new NativeButton("Attach grid to container 1",
+                e -> container1.add(grid));
+        attach1.setId("detachable-grid-attach-1");
+        NativeButton attach2 = new NativeButton("Attach grid to container 2",
+                e -> container2.add(grid));
+        attach2.setId("detachable-grid-attach-2");
+        NativeButton invisible = new NativeButton("Set grid invisble",
+                e -> grid.setVisible(false));
+        invisible.setId("detachable-grid-invisible");
+        NativeButton visible = new NativeButton("Set grid visible",
+                e -> grid.setVisible(true));
+        visible.setId("detachable-grid-visible");
+        add(container1, container2, detach, attach1, attach2, invisible,
+                visible);
     }
 
     private List<Item> generateItems(int amount, int startingIndex) {

--- a/src/test/java/com/vaadin/flow/component/grid/it/GridTestPageIT.java
+++ b/src/test/java/com/vaadin/flow/component/grid/it/GridTestPageIT.java
@@ -183,6 +183,190 @@ public class GridTestPageIT extends AbstractComponentIT {
         });
     }
 
+    @Test
+    public void detachableGrid_changeContainers_itemsAreStillShown() {
+        WebElement container1 = findElement(
+                By.id("detachable-grid-container-1"));
+        WebElement container2 = findElement(
+                By.id("detachable-grid-container-2"));
+        WebElement attach1 = findElement(By.id("detachable-grid-attach-1"));
+        WebElement attach2 = findElement(By.id("detachable-grid-attach-2"));
+
+        WebElement grid = container1.findElement(By.id("detachable-grid"));
+        Map<String, Map<String, ?>> items = getItems(driver, grid);
+        Assert.assertEquals(20, items.size());
+        items.forEach((row, map) -> {
+            Assert.assertEquals("Item " + row, map.get("col0"));
+        });
+        // sets a property on the $connector, to validate that the connector
+        // is not reset when changing containers
+        executeScript("arguments[0].$connector._isUsingTheSameInstance = true",
+                grid);
+
+        attach2.click();
+        grid = container2.findElement(By.id("detachable-grid"));
+        items = getItems(driver, grid);
+        Assert.assertEquals(20, items.size());
+        items.forEach((row, map) -> {
+            Assert.assertEquals("Item " + row, map.get("col0"));
+        });
+        Assert.assertTrue("The $connector instance should be preserved",
+                (Boolean) executeScript(
+                        "return arguments[0].$connector._isUsingTheSameInstance",
+                        grid));
+
+        attach1.click();
+        grid = container1.findElement(By.id("detachable-grid"));
+        items = getItems(driver, grid);
+        Assert.assertEquals(20, items.size());
+        items.forEach((row, map) -> {
+            Assert.assertEquals("Item " + row, map.get("col0"));
+        });
+        Assert.assertTrue("The $connector instance should be preserved",
+                (Boolean) executeScript(
+                        "return arguments[0].$connector._isUsingTheSameInstance",
+                        grid));
+    }
+
+    @Test
+    public void selectItemOnGrid_changeContainers_itemIsStillSelected() {
+        WebElement container1 = findElement(
+                By.id("detachable-grid-container-1"));
+        WebElement container2 = findElement(
+                By.id("detachable-grid-container-2"));
+        WebElement attach1 = findElement(By.id("detachable-grid-attach-1"));
+        WebElement attach2 = findElement(By.id("detachable-grid-attach-2"));
+
+        WebElement grid = container1.findElement(By.id("detachable-grid"));
+        scrollToElement(grid);
+
+        // click to select the first item
+        clickElementWithJs(getRow(grid, 0).findElement(By.tagName("td")));
+        assertSelection(grid, "Item 0");
+
+        attach2.click();
+        grid = container2.findElement(By.id("detachable-grid"));
+        assertSelection(grid, "Item 0");
+        // click to select the second item
+        clickElementWithJs(getRow(grid, 1).findElement(By.tagName("td")));
+        assertSelection(grid, "Item 1");
+
+        attach1.click();
+        grid = container1.findElement(By.id("detachable-grid"));
+        assertSelection(grid, "Item 1");
+    }
+
+    @Test
+    public void detachableGrid_detachAndReattach_itemsAreStillShown() {
+        WebElement container1 = findElement(
+                By.id("detachable-grid-container-1"));
+        WebElement attach1 = findElement(By.id("detachable-grid-attach-1"));
+        WebElement detach = findElement(By.id("detachable-grid-detach"));
+
+        WebElement grid = container1.findElement(By.id("detachable-grid"));
+        scrollToElement(grid);
+
+        Map<String, Map<String, ?>> items = getItems(driver, grid);
+        Assert.assertEquals(20, items.size());
+        items.forEach((row, map) -> {
+            Assert.assertEquals("Item " + row, map.get("col0"));
+        });
+
+        detach.click();
+        waitForElementNotPresent(By.id("detachable-grid"));
+        attach1.click();
+        grid = container1.findElement(By.id("detachable-grid"));
+        items = getItems(driver, grid);
+        Assert.assertEquals(20, items.size());
+        items.forEach((row, map) -> {
+            Assert.assertEquals("Item " + row, map.get("col0"));
+        });
+    }
+
+    @Test
+    public void selectItemOnGrid_detachAndReattach_itemIsStillSelected() {
+        WebElement container1 = findElement(
+                By.id("detachable-grid-container-1"));
+        WebElement attach1 = findElement(By.id("detachable-grid-attach-1"));
+        WebElement detach = findElement(By.id("detachable-grid-detach"));
+
+        WebElement grid = container1.findElement(By.id("detachable-grid"));
+        scrollToElement(grid);
+
+        // click to select the first item
+        clickElementWithJs(getRow(grid, 0).findElement(By.tagName("td")));
+        assertSelection(grid, "Item 0");
+
+        detach.click();
+        waitForElementNotPresent(By.id("detachable-grid"));
+        attach1.click();
+        grid = container1.findElement(By.id("detachable-grid"));
+        assertSelection(grid, "Item 0");
+    }
+
+    @Test
+    public void detachableGrid_setInvisibleAndVisible_itemsAreStillShown() {
+        WebElement container1 = findElement(
+                By.id("detachable-grid-container-1"));
+        WebElement invisible = findElement(By.id("detachable-grid-invisible"));
+        WebElement visible = findElement(By.id("detachable-grid-visible"));
+
+        WebElement grid = container1.findElement(By.id("detachable-grid"));
+        scrollToElement(grid);
+
+        Map<String, Map<String, ?>> items = getItems(driver, grid);
+        Assert.assertEquals(20, items.size());
+        items.forEach((row, map) -> {
+            Assert.assertEquals("Item " + row, map.get("col0"));
+        });
+        // sets a property on the $connector, to validate that the connector
+        // is not reset when changing visibility
+        executeScript("arguments[0].$connector._isUsingTheSameInstance = true",
+                grid);
+
+        invisible.click();
+        waitUntil(driver -> "true".equals(grid.getAttribute("hidden")));
+        visible.click();
+        waitUntil(driver -> grid.getAttribute("hidden") == null);
+        items = getItems(driver, grid);
+        Assert.assertEquals(20, items.size());
+        items.forEach((row, map) -> {
+            Assert.assertEquals("Item " + row, map.get("col0"));
+        });
+        Assert.assertTrue("The $connector instance should be preserved",
+                (Boolean) executeScript(
+                        "return arguments[0].$connector._isUsingTheSameInstance",
+                        grid));
+    }
+
+    @Test
+    public void detachableGrid_setInvisibleAndVisible_itemIsStillSelected() {
+        WebElement container1 = findElement(
+                By.id("detachable-grid-container-1"));
+        WebElement invisible = findElement(By.id("detachable-grid-invisible"));
+        WebElement visible = findElement(By.id("detachable-grid-visible"));
+
+        WebElement grid = container1.findElement(By.id("detachable-grid"));
+        scrollToElement(grid);
+
+        // click to select the first item
+        clickElementWithJs(getRow(grid, 0).findElement(By.tagName("td")));
+        assertSelection(grid, "Item 0");
+
+        invisible.click();
+        waitUntil(driver -> "true".equals(grid.getAttribute("hidden")));
+        visible.click();
+        waitUntil(driver -> grid.getAttribute("hidden") == null);
+        assertSelection(grid, "Item 0");
+    }
+
+    private void assertSelection(WebElement grid, String value) {
+        Assert.assertTrue(value + " should be selected",
+                (Boolean) executeScript(
+                        "return arguments[0].selectedItems[0].col0 === arguments[1]",
+                        grid, value));
+    }
+
     private void assertItemsArePresent(WebElement grid, String itemIdPrefix,
             int startingIndex, int length) {
         for (int i = 0; i < length; i++) {

--- a/src/test/java/com/vaadin/flow/component/grid/it/GridViewIT.java
+++ b/src/test/java/com/vaadin/flow/component/grid/it/GridViewIT.java
@@ -115,7 +115,9 @@ public class GridViewIT extends TabbedComponentDemoTest {
                 isRowSelected(grid, 0));
 
         // scroll to bottom
-        scroll(grid, 495);
+        for (int i = 0; i < 10; i++) {
+            scroll(grid, 100 + (100 * i));
+        }
         waitUntilCellHasText(grid, "Person 499");
         // select item that is not in cache
         clickElementWithJs(toggleButton);


### PR DESCRIPTION
This fix uses the refactored beforeClientResponse mechanism in Flow. Depends on https://github.com/vaadin/flow/pull/3617

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-flow/105)
<!-- Reviewable:end -->
