### PR TITLE
Add support for heightByRows

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>org.webjars.bowergithub.vaadin</groupId>
             <artifactId>vaadin-grid</artifactId>
-            <version>5.0.0-beta2</version>
+            <version>5.0.0-beta3</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.webjars.bowergithub.vaadin</groupId>

--- a/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -1744,4 +1744,28 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
                 order -> order.getSorted().getComparator(order.getDirection()))
                 .reduce(operator).orElse(null);
     }
+
+    /**
+     * If <code>true</code>, the grid's height is defined by the number of its
+     * rows. All items are fetched from the {@link DataProvider}, and the Grid
+     * shows no vertical scroll bar.
+     * 
+     * @param heightByRows
+     *            <code>true</code> to make Grid compute its height by the
+     *            number of rows, <code>false</code> for the default behavior
+     */
+    public void setHeightByRows(boolean heightByRows) {
+        getElement().setProperty("heightByRows", heightByRows);
+    }
+
+    /**
+     * Gets whether grid's height is defined by the number of its rows.
+     * 
+     * @return <code>true</code> if Grid computes its height by the number of
+     *         rows, <code>false</code> otherwise
+     */
+    @Synchronize("height-by-rows-changed")
+    public boolean isHeightByRows() {
+        return getElement().getProperty("heightByRows", false);
+    }
 }

--- a/src/test/java/com/vaadin/flow/component/grid/demo/GridView.java
+++ b/src/test/java/com/vaadin/flow/component/grid/demo/GridView.java
@@ -319,6 +319,7 @@ public class GridView extends DemoView {
         createHeaderAndFooterUsingTemplates();
         createHeaderAndFooterUsingComponents();
         createBeanGrid();
+        createHeightByRows();
 
         addCard("Grid example model",
                 new Label("These objects are used in the examples above"));
@@ -872,13 +873,39 @@ public class GridView extends DemoView {
         addCard("Using renderers", "Using basic renderers", grid);
     }
 
+    private void createHeightByRows() {
+        // begin-source-example
+        // source-example-heading: Using height by rows
+        Grid<Person> grid = new Grid<>();
+
+        // When using heightByRows, all items are fetched and
+        // Grid uses all the space needed to render everything.
+        grid.setHeightByRows(true);
+
+        List<Person> people = createItems(50);
+        grid.setItems(people);
+
+        grid.addColumn(Person::getName).setHeader("Name");
+        grid.addColumn(Person::getAge).setHeader("Age");
+
+        grid.setSelectionMode(SelectionMode.NONE);
+        // end-source-example
+
+        grid.setId("grid-height-by-rows");
+        addCard("Height by Rows", "Using height by rows", grid);
+    }
+
     private List<Person> getItems() {
         return items;
     }
 
     private static List<Person> createItems() {
+        return createItems(500);
+    }
+
+    private static List<Person> createItems(int number) {
         Random random = new Random(0);
-        return IntStream.range(1, 500)
+        return IntStream.range(1, number)
                 .mapToObj(index -> createPerson(index, random))
                 .collect(Collectors.toList());
     }

--- a/src/test/java/com/vaadin/flow/component/grid/it/GridViewIT.java
+++ b/src/test/java/com/vaadin/flow/component/grid/it/GridViewIT.java
@@ -591,6 +591,21 @@ public class GridViewIT extends TabbedComponentDemoTest {
         assertCellContent("<button>Remove</button>", cells.get(11));
     }
 
+    @Test
+    public void heightByRows_allRowsAreFetched() {
+        openTabAndCheckForErrors("height-by-rows");
+        WebElement grid = findElement(By.id("grid-height-by-rows"));
+        scrollToElement(grid);
+        waitUntilCellHasText(grid, "Person 49");
+
+        Assert.assertEquals("Grid should have heightByRows set to true", "true",
+                grid.getAttribute("heightByRows"));
+
+        List<WebElement> rows = getInShadowRoot(grid, By.id("items"))
+                .findElements(By.cssSelector("tr"));
+        Assert.assertEquals("Grid should have 49 rows", 49, rows.size());
+    }
+
     private void assertRendereredContent(String expected, WebElement cell) {
         Assert.assertThat(cell.getAttribute("innerHTML"), CoreMatchers.allOf(
                 CoreMatchers.startsWith("<flow-grid-component-renderer"),


### PR DESCRIPTION
Update Grid webjar to 5.0.0.beta3. Add support for the heightByRows flag, and add a demo for it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-flow/108)
<!-- Reviewable:end -->
