### PR TITLE
Add a small sleep to test.

### DIFF
--- a/src/test/java/com/vaadin/flow/component/grid/it/GridViewIT.java
+++ b/src/test/java/com/vaadin/flow/component/grid/it/GridViewIT.java
@@ -414,6 +414,12 @@ public class GridViewIT extends TabbedComponentDemoTest {
         clickElementWithJs(updateButton);
 
         clickElementWithJs(getRow(grid, 0).findElement(By.tagName("td")));
+        try {
+            // sleep for a while so we don't try to use a stale element.
+            Thread.sleep(500);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
         assertComponentRendereredDetails(grid, 0, "SomeOtherName");
 
         idField.sendKeys(Keys.BACK_SPACE, "2");

--- a/src/test/java/com/vaadin/flow/component/grid/it/GridViewIT.java
+++ b/src/test/java/com/vaadin/flow/component/grid/it/GridViewIT.java
@@ -416,7 +416,7 @@ public class GridViewIT extends TabbedComponentDemoTest {
         clickElementWithJs(getRow(grid, 0).findElement(By.tagName("td")));
         try {
             // sleep for a while so we don't try to use a stale element.
-            Thread.sleep(500);
+            Thread.sleep(1000);
         } catch (InterruptedException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
The tests randomly fails on a StaleElementReferenceException
that happens when we `waitFor` to eagerly before the old data
has changed and we try to read data after/during the change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-flow/126)
<!-- Reviewable:end -->
