### PR TITLE
Add support for disabled Grid

### DIFF
--- a/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -1801,6 +1801,12 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
     @Override
     public void onEnabledStateChange(boolean enabled) {
         super.onEnabledStateChange(enabled);
+
+        /*
+         * The DataCommunicator needs to be reset so components rendered inside
+         * the cells can be updated to the new enabled state. The enabled state
+         * is passed as a property to the client via DataGenerators.
+         */
         getDataCommunicator().reset();
     }
 }

--- a/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -74,6 +74,7 @@ import com.vaadin.flow.data.selection.SelectionModel;
 import com.vaadin.flow.data.selection.SelectionModel.Single;
 import com.vaadin.flow.data.selection.SingleSelect;
 import com.vaadin.flow.data.selection.SingleSelectionListener;
+import com.vaadin.flow.dom.DisabledUpdateMode;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.SerializableComparator;
 import com.vaadin.flow.function.ValueProvider;
@@ -1662,12 +1663,12 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
         return item;
     }
 
-    @ClientDelegate
+    @ClientDelegate(DisabledUpdateMode.ALWAYS)
     private void confirmUpdate(int id) {
         getDataCommunicator().confirmUpdate(id);
     }
 
-    @ClientDelegate
+    @ClientDelegate(DisabledUpdateMode.ALWAYS)
     private void setRequestedRange(int start, int length) {
         getDataCommunicator().setRequestedRange(start, length);
     }
@@ -1795,5 +1796,11 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
     @Synchronize("height-by-rows-changed")
     public boolean isHeightByRows() {
         return getElement().getProperty("heightByRows", false);
+    }
+
+    @Override
+    public void onEnabledStateChange(boolean enabled) {
+        super.onEnabledStateChange(enabled);
+        getDataCommunicator().reset();
     }
 }

--- a/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -22,6 +22,9 @@ window.gridConnector = {
       if (selectionMode === 'NONE') {
         return;
       }
+      if (userOriginated && (grid.getAttribute('disabled') || grid.getAttribute('disabled') === '')) {
+          return;
+      }
       if (selectionMode === 'SINGLE') {
         grid.selectedItems = [];
         selectedKeys = {};

--- a/src/test/java/com/vaadin/flow/component/grid/demo/GridView.java
+++ b/src/test/java/com/vaadin/flow/component/grid/demo/GridView.java
@@ -67,7 +67,6 @@ import com.vaadin.flow.router.Route;
 public class GridView extends DemoView {
 
     public static List<Person> items = new ArrayList<>();
-
     static {
         items = createItems();
     }
@@ -228,7 +227,8 @@ public class GridView extends DemoView {
         /**
          * Creates a new component with the given item.
          *
-         * @param person the person to set
+         * @param person
+         *            the person to set
          */
         public PersonComponent(Person person) {
             this.addClickListener(event -> {
@@ -309,7 +309,6 @@ public class GridView extends DemoView {
             this.add(hlayout);
         }
     }
-
     // end-source-example
 
     @Override
@@ -332,6 +331,7 @@ public class GridView extends DemoView {
         createBeanGrid();
         createHeightByRows();
         createBasicFeatures();
+        createDisabledGrid();
 
         addCard("Grid example model",
                 new Label("These objects are used in the examples above"));
@@ -966,6 +966,34 @@ public class GridView extends DemoView {
 
         grid.setId("grid-basic-feature");
         addCard("Basic Features", "Grid Basic Features Demo", grid);
+    }
+
+    private void createDisabledGrid() {
+        // begin-source-example
+        // source-example-heading: Disabled grid
+        Grid<Person> grid = new Grid<>();
+
+        List<Person> people = createItems(500);
+        grid.setItems(people);
+
+        grid.addColumn(Person::getName).setHeader("Name");
+        grid.addColumn(Person::getAge).setHeader("Age");
+        grid.addColumn(new NativeButtonRenderer<>("Button"))
+                .setHeader("Action");
+
+        grid.setSelectionMode(SelectionMode.SINGLE);
+
+        // The selection and action button won't work, but the scrolling will
+        grid.setEnabled(false);
+        // end-source-example
+
+        NativeButton toggleEnable = new NativeButton("Toggle enable",
+                evt -> grid.setEnabled(!grid.isEnabled()));
+        toggleEnable.setId("disabled-grid-toggle-enable");
+        Div div = new Div(toggleEnable);
+
+        grid.setId("disabled-grid");
+        addCard("Disabled grid", grid, div);
     }
 
     private List<Person> getItems() {

--- a/src/test/java/com/vaadin/flow/component/grid/it/DisabledGridIT.java
+++ b/src/test/java/com/vaadin/flow/component/grid/it/DisabledGridIT.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.it;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.flow.component.grid.testbench.GridElement;
+import com.vaadin.flow.component.grid.testbench.GridTHTDElement;
+import com.vaadin.flow.component.grid.testbench.GridTRElement;
+import com.vaadin.flow.testutil.AbstractComponentIT;
+import com.vaadin.flow.testutil.TestPath;
+
+@TestPath("disabled-grid")
+public class DisabledGridIT extends AbstractComponentIT {
+
+    @Test
+    public void gridIsDisabled_renderedButtonsAreDisabled() {
+        open();
+
+        WebElement message = findElement(By.id("message"));
+        GridElement grid = $(GridElement.class).id("grid");
+        GridTRElement row = grid.getRow(0);
+        GridTHTDElement cell = row.getCell(grid.getColumn("Button renderer"));
+        WebElement button = cell.getContext().findElement(By.tagName("button"));
+
+        Assert.assertTrue("The rendered button should be enabled",
+                button.isEnabled());
+
+        WebElement toggleEnabled = findElement(By.id("toggleEnabled"));
+        toggleEnabled.click();
+
+        row = grid.getRow(0);
+        cell = row.getCell(grid.getColumn("Button renderer"));
+        button = cell.getContext().findElement(By.tagName("button"));
+        Assert.assertFalse("The rendered button should be disabled",
+                button.isEnabled());
+
+        button = cell.getContext().findElement(By.tagName("button"));
+        executeScript("arguments[0].disabled = false", button);
+        button.click();
+
+        Assert.assertTrue("The message should be empty",
+                message.getText().isEmpty());
+    }
+
+}

--- a/src/test/java/com/vaadin/flow/component/grid/it/DisabledGridPage.java
+++ b/src/test/java/com/vaadin/flow/component/grid/it/DisabledGridPage.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.it;
+
+import java.util.Arrays;
+
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.data.renderer.NativeButtonRenderer;
+import com.vaadin.flow.function.ValueProvider;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.theme.NoTheme;
+
+@Route("disabled-grid")
+@NoTheme
+public class DisabledGridPage extends Div {
+
+    public DisabledGridPage() {
+        Div message = new Div();
+        message.setId("message");
+
+        Grid<String> grid = new Grid<>();
+        grid.setId("grid");
+        grid.setItems(Arrays.asList("Item 1", "Item 2", "Item 3"));
+        grid.addColumn(ValueProvider.identity()).setHeader("Item");
+        grid.addColumn(new NativeButtonRenderer<>("Native button",
+                item -> message.setText(
+                        "ERROR!!! This listener should not be triggered!!!")))
+                .setHeader("Button renderer");
+
+        NativeButton toggleEnabled = new NativeButton("Toggle enabled",
+                event -> grid.setEnabled(!grid.isEnabled()));
+        toggleEnabled.setId("toggleEnabled");
+
+        add(grid, message, toggleEnabled);
+    }
+
+}

--- a/src/test/java/com/vaadin/flow/component/grid/it/GridViewIT.java
+++ b/src/test/java/com/vaadin/flow/component/grid/it/GridViewIT.java
@@ -34,6 +34,7 @@ import org.openqa.selenium.WebElement;
 import com.vaadin.flow.component.grid.demo.GridView;
 import com.vaadin.flow.component.grid.testbench.GridElement;
 import com.vaadin.flow.component.grid.testbench.GridTHTDElement;
+import com.vaadin.flow.component.grid.testbench.GridTRElement;
 import com.vaadin.flow.data.provider.QuerySortOrder;
 import com.vaadin.flow.demo.TabbedComponentDemoTest;
 import com.vaadin.testbench.TestBenchElement;
@@ -596,6 +597,32 @@ public class GridViewIT extends TabbedComponentDemoTest {
         Assert.assertEquals(
                 "The first header should be \"Company\" in the Grid",
                 "Company", grid.getHeaderCell(0).getInnerHTML());
+    }
+    
+    @Test
+    public void disabledGrid_itemsAreDisabled() {
+        openTabAndCheckForErrors("");
+        GridElement grid = $(GridElement.class).id("disabled-grid");
+        scrollToElement(grid);
+        waitUntil(driver -> grid.getRowCount() > 0);
+        Assert.assertFalse("Grid should be disabled", grid.isEnabled());
+
+        GridTRElement row = grid.getRow(0);
+        GridTHTDElement cell = row.getCell(grid.getColumn("Action"));
+        WebElement button = cell.getContext().findElement(By.tagName("button"));
+
+        Assert.assertFalse("The rendered button should be disabled",
+                button.isEnabled());
+
+        grid.scrollToRow(498);
+        waitUntil(driver -> grid.getRowCount() == 499);
+
+        row = grid.getRow(498);
+        cell = row.getCell(grid.getColumn("Action"));
+        button = cell.getContext().findElement(By.tagName("button"));
+
+        Assert.assertFalse("The rendered button should be disabled",
+                button.isEnabled());
     }
 
     private WebElement getCellContent(GridTHTDElement cell) {


### PR DESCRIPTION
Disabled Grids don't allow selection, expand/collapse of details rows and all input/selection elements inside it are disabled (they don't fire events to the server). But scrolling through the items still work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-flow/148)
<!-- Reviewable:end -->
