### PR TITLE
Fix the sorting when Components are used in the header

### DIFF
--- a/src/main/java/com/vaadin/flow/component/grid/GridSorterComponentRenderer.java
+++ b/src/main/java/com/vaadin/flow/component/grid/GridSorterComponentRenderer.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid;
+
+import java.util.Optional;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.grid.Grid.Column;
+import com.vaadin.flow.data.provider.ComponentDataGenerator;
+import com.vaadin.flow.data.provider.DataGenerator;
+import com.vaadin.flow.data.provider.DataKeyMapper;
+import com.vaadin.flow.data.renderer.ComponentRenderer;
+import com.vaadin.flow.data.renderer.Rendering;
+import com.vaadin.flow.dom.Element;
+
+/**
+ * Internal component renderer for sortable headers inside Grid.
+ * 
+ * @author Vaadin Ltd.
+ *
+ * @param <SOURCE>
+ *            the model type
+ */
+class GridSorterComponentRenderer<SOURCE>
+        extends ComponentRenderer<Component, SOURCE> {
+
+    private final Column<?> column;
+    private final Component component;
+
+    /**
+     * Creates a new renderer for a specific column, using the defined
+     * component.
+     * 
+     * @param column
+     *            The column which header should be rendered
+     * @param component
+     *            The component to be used by the renderer
+     */
+    public GridSorterComponentRenderer(Column<?> column, Component component) {
+        this.column = column;
+        this.component = component;
+    }
+
+    @Override
+    public Rendering<SOURCE> render(Element container,
+            DataKeyMapper<SOURCE> keyMapper, Element contentTemplate) {
+
+        GridSorterComponentRendering rendering = new GridSorterComponentRendering(
+                contentTemplate);
+
+        container.getNode()
+                .runWhenAttached(ui -> ui.getInternals().getStateTree()
+                        .beforeClientResponse(container.getNode(),
+                                context -> setupTemplateWhenAttached(
+                                        context.getUI(), container, rendering,
+                                        keyMapper)));
+        return rendering;
+    }
+
+    private void setupTemplateWhenAttached(UI ui, Element owner,
+            GridSorterComponentRendering rendering,
+            DataKeyMapper<SOURCE> keyMapper) {
+        String appId = ui.getInternals().getAppId();
+        Element templateElement = rendering.getTemplateElement();
+        owner.appendChild(templateElement);
+
+        Element container = new Element("div");
+        owner.appendVirtualChild(container);
+        rendering.setContainer(container);
+        String templateInnerHtml;
+
+        if (component != null) {
+            container.appendChild(component.getElement());
+
+            templateInnerHtml = String.format(
+                    "<flow-component-renderer appid=\"%s\" nodeid=\"%s\"></flow-component-renderer>",
+                    appId, component.getElement().getNode().getId());
+        } else {
+            templateInnerHtml = "";
+        }
+
+        /*
+         * The renderer must set the base header template back to the column, so
+         * if/when the sortable state is changed by the developer, the column
+         * knows how to add or remove the grid sorter.
+         */
+        column.setBaseHeaderTemplate(templateInnerHtml);
+        if (column.isSortable()) {
+            templateInnerHtml = column.addGridSorter(templateInnerHtml);
+        }
+
+        templateElement.setProperty("innerHTML", templateInnerHtml);
+    }
+
+    private class GridSorterComponentRendering extends
+            ComponentDataGenerator<SOURCE> implements Rendering<SOURCE> {
+
+        private Element templateElement;
+
+        public GridSorterComponentRendering(Element templateElement) {
+            super(GridSorterComponentRenderer.this, null);
+            this.templateElement = templateElement;
+        }
+
+        @Override
+        public Element getTemplateElement() {
+            return templateElement;
+        }
+
+        @Override
+        public Optional<DataGenerator<SOURCE>> getDataGenerator() {
+            return Optional.of(this);
+        }
+    }
+
+}

--- a/src/main/java/com/vaadin/flow/component/grid/GridSorterComponentRenderer.java
+++ b/src/main/java/com/vaadin/flow/component/grid/GridSorterComponentRenderer.java
@@ -126,5 +126,4 @@ class GridSorterComponentRenderer<SOURCE>
             return Optional.of(this);
         }
     }
-
 }

--- a/src/test/java/com/vaadin/flow/component/grid/it/GridViewIT.java
+++ b/src/test/java/com/vaadin/flow/component/grid/it/GridViewIT.java
@@ -501,22 +501,32 @@ public class GridViewIT extends TabbedComponentDemoTest {
     @Test
     public void gridWithHeaderWithComponentRenderer_headerAndFooterAreRenderered() {
         openTabAndCheckForErrors("using-components");
-        WebElement grid = findElement(By.id("grid-header-with-components"));
+
+        GridElement grid = $(GridElement.class)
+                .id("grid-header-with-components");
         scrollToElement(grid);
 
+        GridTHTDElement headerCell = grid.getHeaderCell(0);
+        assertComponentRendereredHeaderCell(headerCell, "<label>Name</label>",
+                true);
+
+        headerCell = grid.getHeaderCell(1);
+        assertComponentRendereredHeaderCell(headerCell, "<label>Age</label>",
+                true);
+
+        headerCell = grid.getHeaderCell(2);
+        assertComponentRendereredHeaderCell(headerCell, "<label>Street</label>",
+                false);
+
+        headerCell = grid.getHeaderCell(3);
+        assertComponentRendereredHeaderCell(headerCell,
+                "<label>Postal Code</label>", false);
+        
         Assert.assertTrue(
                 "There should be a cell with the renderered 'Basic Information' header",
                 hasComponentRendereredHeaderCell(grid,
                         "<label>Basic Information</label>"));
-
-        Assert.assertTrue(
-                "There should be a cell with the renderered 'Name' header",
-                hasComponentRendereredHeaderCell(grid, "<label>Name</label>"));
-
-        Assert.assertTrue(
-                "There should be a cell with the renderered 'Age' header",
-                hasComponentRendereredHeaderCell(grid, "<label>Age</label>"));
-
+        
         Assert.assertTrue("There should be a cell with the renderered footer",
                 hasComponentRendereredHeaderCell(grid,
                         "<label>Total: 499 people</label>"));
@@ -705,6 +715,22 @@ public class GridViewIT extends TabbedComponentDemoTest {
                 "flow-component-renderer");
     }
 
+    private void assertComponentRendereredHeaderCell(GridTHTDElement headerCell,
+            String text, boolean withSorter) {
+
+        String html = headerCell.getInnerHTML();
+        if (withSorter) {
+            Assert.assertThat(html,
+                    CoreMatchers.containsString("<vaadin-grid-sorter"));
+        } else {
+            Assert.assertThat(html, CoreMatchers
+                    .not(CoreMatchers.containsString("<vaadin-grid-sorter")));
+        }
+        Assert.assertThat(html,
+                CoreMatchers.containsString("<flow-component-renderer"));
+        Assert.assertThat(html, CoreMatchers.containsString(text));
+    }
+    
     private boolean hasComponentRendereredHeaderCell(WebElement grid,
             String text) {
         return hasComponentRendereredCell(grid, text,

--- a/src/test/java/com/vaadin/flow/component/grid/testbench/GridElement.java
+++ b/src/test/java/com/vaadin/flow/component/grid/testbench/GridElement.java
@@ -269,7 +269,7 @@ public class GridElement extends TestBenchElement {
      *            the index of the column
      * @return a cell element for the footer cell
      */
-    public TestBenchElement getFooterCell(int columnIndex) {
+    public GridTHTDElement getFooterCell(int columnIndex) {
         return getVisibleColumns().get(columnIndex).getFooterCell();
     }
 


### PR DESCRIPTION
This patch fixes the problem introduced with the BasicRenderers rework, that prevented headers to be sortable when Components (and ComponentRenderers) are used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-flow/159)
<!-- Reviewable:end -->
