### PR TITLE
Render header components only once in a roundtrip

### DIFF
--- a/src/main/java/com/vaadin/flow/component/grid/AbstractColumn.java
+++ b/src/main/java/com/vaadin/flow/component/grid/AbstractColumn.java
@@ -86,12 +86,8 @@ public class AbstractColumn<T extends AbstractColumn<T>> extends Component
 
     protected void setHeaderRenderer(Renderer<?> renderer) {
         headerRenderer = renderer;
-        if (renderer instanceof ComponentRenderer<?, ?>) {
-            getElement().getNode().runWhenAttached(ui -> ui
-                    .beforeClientResponse(this, context -> renderHeader()));
-        } else {
-            renderHeader();
-        }
+        getElement().getNode().runWhenAttached(
+                ui -> ui.beforeClientResponse(this, context -> renderHeader()));
     }
 
     protected Rendering<?> renderHeader() {
@@ -110,12 +106,8 @@ public class AbstractColumn<T extends AbstractColumn<T>> extends Component
 
     protected void setFooterRenderer(Renderer<?> renderer) {
         footerRenderer = renderer;
-        if (renderer instanceof ComponentRenderer<?, ?>) {
-            getElement().getNode().runWhenAttached(ui -> ui
-                    .beforeClientResponse(this, context -> renderFooter()));
-        } else {
-            renderFooter();
-        }
+        getElement().getNode().runWhenAttached(
+                ui -> ui.beforeClientResponse(this, context -> renderFooter()));
     }
 
     protected Rendering<?> renderFooter() {

--- a/src/main/java/com/vaadin/flow/component/grid/AbstractColumn.java
+++ b/src/main/java/com/vaadin/flow/component/grid/AbstractColumn.java
@@ -84,50 +84,63 @@ public class AbstractColumn<T extends AbstractColumn<T>> extends Component
         return !getElement().getProperty("hidden", false);
     }
 
-    protected Rendering<?> renderHeader(Renderer<?> renderer) {
+    protected void setHeaderRenderer(Renderer<?> renderer) {
         headerRenderer = renderer;
+        if (renderer instanceof ComponentRenderer<?, ?>) {
+            getElement().getNode().runWhenAttached(ui -> ui
+                    .beforeClientResponse(this, context -> renderHeader()));
+        } else {
+            renderHeader();
+        }
+    }
+
+    protected Rendering<?> renderHeader() {
         if (headerTemplate != null) {
             headerTemplate.removeFromParent();
             headerTemplate = null;
         }
-        if (renderer == null) {
+        if (headerRenderer == null) {
             return null;
         }
-        Rendering<?> rendering = renderer.render(getElement(), null);
+        Rendering<?> rendering = headerRenderer.render(getElement(), null);
         headerTemplate = rendering.getTemplateElement();
         headerTemplate.setAttribute("class", "header");
         return rendering;
     }
 
-    protected Rendering<?> renderFooter(Renderer<?> renderer) {
+    protected void setFooterRenderer(Renderer<?> renderer) {
         footerRenderer = renderer;
+        renderFooter();
+    }
+
+    protected Rendering<?> renderFooter() {
         if (footerTemplate != null) {
             footerTemplate.removeFromParent();
             footerTemplate = null;
         }
-        if (renderer == null) {
+        if (footerRenderer == null) {
             return null;
         }
-        Rendering<?> rendering = renderer.render(getElement(), null);
+        Rendering<?> rendering = footerRenderer.render(getElement(), null);
         footerTemplate = rendering.getTemplateElement();
         footerTemplate.setAttribute("class", "footer");
         return rendering;
     }
 
     protected void setHeaderText(String text) {
-        renderHeader(TemplateRenderer.of(HtmlUtils.escape(text)));
+        setHeaderRenderer(TemplateRenderer.of(HtmlUtils.escape(text)));
     }
 
     protected void setFooterText(String text) {
-        renderFooter(TemplateRenderer.of(HtmlUtils.escape(text)));
+        setFooterRenderer(TemplateRenderer.of(HtmlUtils.escape(text)));
     }
 
     protected void setHeaderComponent(Component component) {
-        renderHeader(new ComponentRenderer<>(() -> component));
+        setHeaderRenderer(new ComponentRenderer<>(() -> component));
     }
 
     protected void setFooterComponent(Component component) {
-        renderFooter(new ComponentRenderer<>(() -> component));
+        setFooterRenderer(new ComponentRenderer<>(() -> component));
     }
 
     protected Renderer<?> getHeaderRenderer() {

--- a/src/main/java/com/vaadin/flow/component/grid/AbstractColumn.java
+++ b/src/main/java/com/vaadin/flow/component/grid/AbstractColumn.java
@@ -110,7 +110,12 @@ public class AbstractColumn<T extends AbstractColumn<T>> extends Component
 
     protected void setFooterRenderer(Renderer<?> renderer) {
         footerRenderer = renderer;
-        renderFooter();
+        if (renderer instanceof ComponentRenderer<?, ?>) {
+            getElement().getNode().runWhenAttached(ui -> ui
+                    .beforeClientResponse(this, context -> renderFooter()));
+        } else {
+            renderFooter();
+        }
     }
 
     protected Rendering<?> renderFooter() {

--- a/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -622,7 +622,7 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
             /*
              * Uses the special renderer to take care of the vaadin-grid-sorter.
              */
-            super.renderHeader(
+            super.setHeaderRenderer(
                     new GridSorterComponentRenderer<>(this, headerComponent));
         }
 
@@ -630,8 +630,8 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
          * This method is invoked only for TemplateRenderers.
          */
         @Override
-        protected Rendering<?> renderHeader(Renderer<?> renderer) {
-            Rendering<?> rendering = super.renderHeader(renderer);
+        protected Rendering<?> renderHeader() {
+            Rendering<?> rendering = super.renderHeader();
             if (rendering == null) {
                 return null;
             }
@@ -1282,12 +1282,13 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
         IntStream.range(0, groups.size()).forEach(i -> {
             // Move templates from columns to column-groups
             if (forFooterRow) {
-                groups.get(i).renderFooter(columns.get(i).getFooterRenderer());
-                columns.get(i).renderFooter(null);
+                groups.get(i).setFooterRenderer(columns.get(i).getFooterRenderer());
+                columns.get(i).setFooterRenderer(null);
             }
             if (forHeaderRow) {
-                groups.get(i).renderHeader(columns.get(i).getHeaderRenderer());
-                columns.get(i).renderHeader(null);
+                groups.get(i)
+                        .setHeaderRenderer(columns.get(i).getHeaderRenderer());
+                columns.get(i).setHeaderRenderer(null);
             }
         });
 

--- a/src/test/java/com/vaadin/flow/component/grid/HeaderFooterTest.java
+++ b/src/test/java/com/vaadin/flow/component/grid/HeaderFooterTest.java
@@ -90,40 +90,6 @@ public class HeaderFooterTest {
     }
 
     @Test
-    public void prependHeaderRow_headerLayerAdded() {
-        grid.prependHeaderRow();
-        List<List<Element>> layers = getColumnLayersAndAssertCount(1);
-        Assert.assertTrue("Columns should have headers but no footers",
-                isHeaderRow(layers.get(0)) && !isFooterRow(layers.get(0)));
-    }
-
-    @Test
-    public void appendHeaderRow_headerLayerAdded() {
-        grid.appendHeaderRow();
-        List<List<Element>> layers = getColumnLayersAndAssertCount(1);
-        Assert.assertTrue("Columns should have headers but no footers",
-                isHeaderRow(layers.get(0)) && !isFooterRow(layers.get(0)));
-    }
-
-    @Test
-    public void addHeaderAndFooterRow_oneLayerWithBothTemplatesAdded() {
-        grid.appendHeaderRow();
-        grid.appendFooterRow();
-        assertOneLayerWithHeaderAndFooter();
-
-        init();
-        grid.prependHeaderRow();
-        grid.prependFooterRow();
-        assertOneLayerWithHeaderAndFooter();
-    }
-
-    private void assertOneLayerWithHeaderAndFooter() {
-        List<List<Element>> layers = getColumnLayersAndAssertCount(1);
-        Assert.assertTrue("Columns should have headers but no footers",
-                isHeaderRow(layers.get(0)) && isFooterRow(layers.get(0)));
-    }
-
-    @Test
     public void appendHeaderRows_firstOnTop() {
         HeaderRow first = grid.appendHeaderRow();
         HeaderRow second = grid.appendHeaderRow();

--- a/src/test/java/com/vaadin/flow/component/grid/it/GridHeaderFooterRowIT.java
+++ b/src/test/java/com/vaadin/flow/component/grid/it/GridHeaderFooterRowIT.java
@@ -43,6 +43,61 @@ public class GridHeaderFooterRowIT extends AbstractComponentIT {
     }
 
     @Test
+    public void appendHeader_headerTemplatesAdded() {
+        clickButton("append-header");
+        assertColumnsHaveTemplates("header", true);
+        assertColumnsHaveTemplates("footer", false);
+    }
+
+    @Test
+    public void prependHeader_headerTemplatesAdded() {
+        clickButton("prepend-header");
+        assertColumnsHaveTemplates("header", true);
+        assertColumnsHaveTemplates("footer", false);
+    }
+
+    @Test
+    public void appendFooter_footerTemplatesAdded() {
+        clickButton("append-footer");
+        assertColumnsHaveTemplates("header", false);
+        assertColumnsHaveTemplates("footer", true);
+    }
+
+    @Test
+    public void prependFooter_footerTemplatesAdded() {
+        clickButton("prepend-footer");
+        assertColumnsHaveTemplates("header", false);
+        assertColumnsHaveTemplates("footer", true);
+    }
+
+    @Test
+    public void appendHeader_appendFooter_headerAndFooterTemplatesAdded() {
+        clickButton("append-header");
+        clickButton("append-footer");
+        assertColumnsHaveTemplates("header", true);
+        assertColumnsHaveTemplates("footer", true);
+    }
+
+    private void assertColumnsHaveTemplates(String className,
+            boolean haveTemplates) {
+        List<WebElement> columns = grid
+                .findElements(By.className("vaadin-grid-column"));
+        columns.forEach(col -> {
+            List<WebElement> templates = col
+                    .findElements(By.tagName("template"));
+            if (haveTemplates) {
+                Assert.assertTrue(
+                        templates.stream().allMatch(template -> template
+                                .getAttribute("class").contains(className)));
+            } else {
+                Assert.assertTrue(
+                        templates.stream().noneMatch(template -> template
+                                .getAttribute("class").contains(className)));
+            }
+        });
+    }
+
+    @Test
     public void addHeadersAfterGridIsRendered_cellsAreRenderedInCorrectOrder() {
         clickButton("append-header");
         assertHeaderOrder(0);

--- a/src/test/java/com/vaadin/flow/component/grid/it/GridHeaderRowWithComponentsIT.java
+++ b/src/test/java/com/vaadin/flow/component/grid/it/GridHeaderRowWithComponentsIT.java
@@ -61,6 +61,23 @@ public class GridHeaderRowWithComponentsIT extends AbstractComponentIT {
                 CoreMatchers.containsString("<label>bar</label>"));
     }
 
+    @Test
+    public void prependHeader_setText_setComponent_componentOverridesText() {
+        findElement(By.id("set-both-text-and-component")).click();
+        String headerContent = getHeaderCells().get(0)
+                .getAttribute("innerHTML");
+
+        Assert.assertThat(
+                "The header cell should not contain the text after "
+                        + "overriding it with a component",
+                headerContent,
+                CoreMatchers.not(CoreMatchers.containsString("this is text")));
+        Assert.assertThat(
+                "The header cell should contain the component which was last set",
+                headerContent, CoreMatchers
+                        .containsString("<label>this is component</label>"));
+    }
+
     private List<WebElement> getHeaderCells() {
         WebElement thead = findInShadowRoot(grid, By.id("header")).get(0);
         List<WebElement> headers = thead.findElements(By.tagName("th"));

--- a/src/test/java/com/vaadin/flow/component/grid/it/GridHeaderRowWithComponentsIT.java
+++ b/src/test/java/com/vaadin/flow/component/grid/it/GridHeaderRowWithComponentsIT.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.it;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.flow.component.grid.testbench.GridElement;
+import com.vaadin.flow.testutil.AbstractComponentIT;
+import com.vaadin.flow.testutil.TestPath;
+
+@TestPath("grid-header-row-with-components")
+public class GridHeaderRowWithComponentsIT extends AbstractComponentIT {
+
+    private GridElement grid;
+
+    @Before
+    public void init() {
+        open();
+        grid = $(GridElement.class).id("grid");
+    }
+
+    @Test // for https://github.com/vaadin/vaadin-grid-flow/issues/172
+    public void appendHeaderRowsWithComponents_headerCellsAreRenderedInCorrectOrder() {
+        List<WebElement> headerCells = getHeaderCells();
+        Assert.assertEquals(
+                "There should be 2 header cells after appending 2 header rows for "
+                        + "a Grid with one column",
+                2, headerCells.size());
+
+        Assert.assertThat(
+                "The first header cell should contain the component "
+                        + "of the first appended header row",
+                headerCells.get(0).getAttribute("innerHTML"),
+                CoreMatchers.containsString("<label>foo</label>"));
+
+        Assert.assertThat(
+                "The second header cell should contain the component "
+                        + "of the second appended header row",
+                headerCells.get(1).getAttribute("innerHTML"),
+                CoreMatchers.containsString("<label>bar</label>"));
+    }
+
+    private List<WebElement> getHeaderCells() {
+        WebElement thead = findInShadowRoot(grid, By.id("header")).get(0);
+        List<WebElement> headers = thead.findElements(By.tagName("th"));
+
+        List<String> cellNames = headers.stream().map(header -> header
+                .findElement(By.tagName("slot")).getAttribute("name"))
+                .collect(Collectors.toList());
+
+        List<WebElement> headerCells = cellNames.stream()
+                .map(name -> grid.findElement(By.cssSelector(
+                        "vaadin-grid-cell-content[slot='" + name + "']")))
+                .collect(Collectors.toList());
+
+        return headerCells;
+    }
+
+}

--- a/src/test/java/com/vaadin/flow/component/grid/it/GridHeaderRowWithComponentsPage.java
+++ b/src/test/java/com/vaadin/flow/component/grid/it/GridHeaderRowWithComponentsPage.java
@@ -22,6 +22,7 @@ import com.vaadin.flow.component.grid.Grid.Column;
 import com.vaadin.flow.component.grid.HeaderRow;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Label;
+import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.function.ValueProvider;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.theme.NoTheme;
@@ -44,6 +45,16 @@ public class GridHeaderRowWithComponentsPage extends Div {
         row1.getCell(column).setComponent(new Label("foo"));
         HeaderRow row2 = grid.appendHeaderRow();
         row2.getCell(column).setComponent(new Label("bar"));
+
+        NativeButton button = new NativeButton(
+                "Prepend header, set first text and then component");
+        button.setId("set-both-text-and-component");
+        button.addClickListener(event -> {
+            HeaderRow topRow = grid.prependHeaderRow();
+            topRow.getCell(column).setText("this is text");
+            topRow.getCell(column).setComponent(new Label("this is component"));
+        });
+        add(button);
     }
 
 }

--- a/src/test/java/com/vaadin/flow/component/grid/it/GridHeaderRowWithComponentsPage.java
+++ b/src/test/java/com/vaadin/flow/component/grid/it/GridHeaderRowWithComponentsPage.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.it;
+
+import java.util.Arrays;
+
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.grid.Grid.Column;
+import com.vaadin.flow.component.grid.HeaderRow;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Label;
+import com.vaadin.flow.function.ValueProvider;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.theme.NoTheme;
+
+/**
+ * Test view that adds header rows with components to a Grid.
+ */
+@Route("grid-header-row-with-components")
+@NoTheme
+public class GridHeaderRowWithComponentsPage extends Div {
+
+    public GridHeaderRowWithComponentsPage() {
+        Grid<String> grid = new Grid<>();
+        grid.setId("grid");
+        grid.setItems(Arrays.asList("Item 1", "Item 2", "Item 3"));
+        Column<String> column = grid.addColumn(ValueProvider.identity());
+        add(grid);
+
+        HeaderRow row1 = grid.appendHeaderRow();
+        row1.getCell(column).setComponent(new Label("foo"));
+        HeaderRow row2 = grid.appendHeaderRow();
+        row2.getCell(column).setComponent(new Label("bar"));
+    }
+
+}


### PR DESCRIPTION
Instead of applying ComponentRenderer for headers every time the
renderer is changed, apply the current renderer beforeClientResponse so
that only the last renderer is used.

Fix #172

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-flow/176)
<!-- Reviewable:end -->
