### PR TITLE
Use the first created HeaderRow as the default

### DIFF
--- a/src/main/java/com/vaadin/flow/component/grid/AbstractColumn.java
+++ b/src/main/java/com/vaadin/flow/component/grid/AbstractColumn.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.component.grid;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Synchronize;
+import com.vaadin.flow.component.grid.Grid.Column;
 import com.vaadin.flow.data.renderer.ComponentRenderer;
 import com.vaadin.flow.data.renderer.Renderer;
 import com.vaadin.flow.data.renderer.Rendering;
@@ -32,7 +33,7 @@ import com.vaadin.flow.internal.HtmlUtils;
  * @param <T>
  *            the subclass type
  */
-public class AbstractColumn<T extends AbstractColumn<T>> extends Component
+abstract class AbstractColumn<T extends AbstractColumn<T>> extends Component
         implements ColumnBase<T> {
 
     protected final Grid<?> grid;
@@ -40,6 +41,12 @@ public class AbstractColumn<T extends AbstractColumn<T>> extends Component
     protected Element footerTemplate;
     private Renderer<?> headerRenderer;
     private Renderer<?> footerRenderer;
+
+    private boolean headerRenderingScheduled;
+    private boolean footerRenderingScheduled;
+
+    private String rawHeaderTemplate;
+    private boolean sortingIndicators;
 
     /**
      * Base constructor with the destination Grid.
@@ -86,11 +93,22 @@ public class AbstractColumn<T extends AbstractColumn<T>> extends Component
 
     protected void setHeaderRenderer(Renderer<?> renderer) {
         headerRenderer = renderer;
-        getElement().getNode().runWhenAttached(
-                ui -> ui.beforeClientResponse(this, context -> renderHeader()));
+        scheduleHeaderRendering();
     }
 
-    protected Rendering<?> renderHeader() {
+    private void scheduleHeaderRendering() {
+        if (headerRenderingScheduled) {
+            return;
+        }
+        headerRenderingScheduled = true;
+        getElement().getNode().runWhenAttached(
+                ui -> ui.beforeClientResponse(this, context -> {
+                    renderHeader();
+                    headerRenderingScheduled = false;
+                }));
+    }
+
+    private Rendering<?> renderHeader() {
         if (headerTemplate != null) {
             headerTemplate.removeFromParent();
             headerTemplate = null;
@@ -101,16 +119,34 @@ public class AbstractColumn<T extends AbstractColumn<T>> extends Component
         Rendering<?> rendering = headerRenderer.render(getElement(), null);
         headerTemplate = rendering.getTemplateElement();
         headerTemplate.setAttribute("class", "header");
+
+        setBaseHeaderTemplate(headerTemplate.getProperty("innerHTML"));
+        if (hasSortingIndicators()) {
+            headerTemplate.setProperty("innerHTML",
+                    addGridSorter(rawHeaderTemplate));
+        }
+
         return rendering;
+    }
+
+    private void scheduleFooterRendering() {
+        if (footerRenderingScheduled) {
+            return;
+        }
+        footerRenderingScheduled = true;
+        getElement().getNode().runWhenAttached(
+                ui -> ui.beforeClientResponse(this, context -> {
+                    renderFooter();
+                    footerRenderingScheduled = false;
+                }));
     }
 
     protected void setFooterRenderer(Renderer<?> renderer) {
         footerRenderer = renderer;
-        getElement().getNode().runWhenAttached(
-                ui -> ui.beforeClientResponse(this, context -> renderFooter()));
+        scheduleFooterRendering();
     }
 
-    protected Rendering<?> renderFooter() {
+    private Rendering<?> renderFooter() {
         if (footerTemplate != null) {
             footerTemplate.removeFromParent();
             footerTemplate = null;
@@ -133,7 +169,10 @@ public class AbstractColumn<T extends AbstractColumn<T>> extends Component
     }
 
     protected void setHeaderComponent(Component component) {
-        setHeaderRenderer(new ComponentRenderer<>(() -> component));
+        /*
+         * Uses the special renderer to take care of the vaadin-grid-sorter.
+         */
+        setHeaderRenderer(new GridSorterComponentRenderer<>(this, component));
     }
 
     protected void setFooterComponent(Component component) {
@@ -147,5 +186,71 @@ public class AbstractColumn<T extends AbstractColumn<T>> extends Component
     protected Renderer<?> getFooterRenderer() {
         return footerRenderer;
     }
+
+    /**
+     * Updates this component to either have sorting indicators according to the
+     * sortable state of the underlying column, or removes the sorting
+     * indicators.
+     * 
+     * @param sortable
+     *            {@code true} to have sorting indicators if the column is
+     *            sortable, {@code false} to not have sorting indicators
+     */
+    protected void updateSortingIndicators(boolean sortable) {
+        if (sortable) {
+            setSortingIndicators(getBottomLevelColumn().isSortable());
+        } else {
+            setSortingIndicators(false);
+        }
+    }
+
+    /**
+     * Sets this component to show sorting indicators or not.
+     * 
+     * @param sortingIndicators
+     *            {@code true} to show sorting indicators, {@code false} to
+     *            remove them
+     */
+    protected void setSortingIndicators(boolean sortingIndicators) {
+        if (this.sortingIndicators == sortingIndicators) {
+            return;
+        }
+        this.sortingIndicators = sortingIndicators;
+        scheduleHeaderRendering();
+    }
+
+    protected boolean hasSortingIndicators() {
+        return sortingIndicators;
+    }
+
+    /*
+     * The original header template is needed for when sorting is enabled or
+     * disabled in a column.
+     */
+    protected void setBaseHeaderTemplate(String headerTemplate) {
+        rawHeaderTemplate = headerTemplate;
+    }
+
+    /*
+     * Adds the sorting webcomponent markup to an existing template.
+     */
+    protected String addGridSorter(String templateInnerHtml) {
+        String escapedColumnId = HtmlUtils
+                .escape(getBottomLevelColumn().getInternalId());
+        return String.format(
+                "<vaadin-grid-sorter path='%s'>%s</vaadin-grid-sorter>",
+                escapedColumnId, templateInnerHtml);
+    }
+
+    /**
+     * Gets the {@code <vaadin-grid-column>} component that is a child of this
+     * component, or this component in case this is a bottom level
+     * {@code <vaadin-grid-column>} component. This method should be called only
+     * on components which have only one such bottom-level column (not on
+     * ColumnGroups with multiple children).
+     * 
+     * @return the bottom column component
+     */
+    protected abstract Column<?> getBottomLevelColumn();
 
 }

--- a/src/main/java/com/vaadin/flow/component/grid/AbstractColumn.java
+++ b/src/main/java/com/vaadin/flow/component/grid/AbstractColumn.java
@@ -103,6 +103,9 @@ abstract class AbstractColumn<T extends AbstractColumn<T>> extends Component
         headerRenderingScheduled = true;
         getElement().getNode().runWhenAttached(
                 ui -> ui.beforeClientResponse(this, context -> {
+                    if (!headerRenderingScheduled) {
+                        return;
+                    }
                     renderHeader();
                     headerRenderingScheduled = false;
                 }));
@@ -136,6 +139,9 @@ abstract class AbstractColumn<T extends AbstractColumn<T>> extends Component
         footerRenderingScheduled = true;
         getElement().getNode().runWhenAttached(
                 ui -> ui.beforeClientResponse(this, context -> {
+                    if (!footerRenderingScheduled) {
+                        return;
+                    }
                     renderFooter();
                     footerRenderingScheduled = false;
                 }));

--- a/src/main/java/com/vaadin/flow/component/grid/ColumnBase.java
+++ b/src/main/java/com/vaadin/flow/component/grid/ColumnBase.java
@@ -27,7 +27,7 @@ import com.vaadin.flow.dom.Element;
  *
  * @author Vaadin Ltd.
  */
-public interface ColumnBase<T extends ColumnBase<T>> extends HasElement {
+interface ColumnBase<T extends ColumnBase<T>> extends HasElement {
 
     /**
      * When set to {@code true}, the column is user-resizable. By default this

--- a/src/main/java/com/vaadin/flow/component/grid/ColumnGroup.java
+++ b/src/main/java/com/vaadin/flow/component/grid/ColumnGroup.java
@@ -18,10 +18,12 @@ package com.vaadin.flow.component.grid;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.HtmlImport;
+import com.vaadin.flow.component.grid.Grid.Column;
 import com.vaadin.flow.dom.Element;
 
 /**
@@ -86,5 +88,24 @@ class ColumnGroup extends AbstractColumn<ColumnGroup> {
     @Override
     public Element getElement() {
         return super.getElement();
+    }
+
+    @Override
+    protected Column<?> getBottomLevelColumn() {
+        return (Column<?>) findBottomLevelColumnElement(getElement())
+                .getComponent().get();
+    }
+
+    private Element findBottomLevelColumnElement(Element element) {
+        Optional<Element> columnGroup = element.getChildren().filter(
+                child -> "vaadin-grid-column-group".equals(child.getTag()))
+                .findFirst();
+        if (columnGroup.isPresent()) {
+            return findBottomLevelColumnElement(columnGroup.get());
+        } else {
+            return element.getChildren().filter(
+                    child -> "vaadin-grid-column".equals(child.getTag()))
+                    .findFirst().get();
+        }
     }
 }

--- a/src/main/java/com/vaadin/flow/component/grid/ColumnLayer.java
+++ b/src/main/java/com/vaadin/flow/component/grid/ColumnLayer.java
@@ -223,4 +223,17 @@ class ColumnLayer {
         return columns;
     }
 
+    /**
+     * Sets whether components on this layer should display the sorting
+     * indicators if the underlying column is sortable.
+     * 
+     * @param sortingIndicators
+     *            {@code true} to make components on this layer to have the
+     *            sorting indicators if the column is sortable, {@code false} to
+     *            not have sorting indicators
+     */
+    protected void updateSortingIndicators(boolean sortingIndicators) {
+        columns.forEach(col -> col.updateSortingIndicators(sortingIndicators));
+    }
+
 }

--- a/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -78,7 +78,6 @@ import com.vaadin.flow.dom.DisabledUpdateMode;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.SerializableComparator;
 import com.vaadin.flow.function.ValueProvider;
-import com.vaadin.flow.internal.HtmlUtils;
 import com.vaadin.flow.internal.JsonSerializer;
 import com.vaadin.flow.internal.JsonUtils;
 import com.vaadin.flow.internal.ReflectTools;
@@ -241,8 +240,6 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
         };
 
         private SerializableComparator<T> comparator;
-
-        private String rawHeaderTemplate;
 
         private Registration columnDataGeneratorRegistration;
 
@@ -526,11 +523,12 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
             }
             this.sortingEnabled = sortable;
 
-            if (headerTemplate != null) {
-                headerTemplate.setProperty("innerHTML",
-                        sortable ? addGridSorter(rawHeaderTemplate)
-                                : rawHeaderTemplate);
+            HeaderRow defaultHeaderRow = getGrid().getDefaultHeaderRow();
+            if (defaultHeaderRow != null) {
+                defaultHeaderRow.getCell(this).getColumn()
+                        .setSortingIndicators(sortable);
             }
+
             return this;
         }
 
@@ -550,16 +548,19 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
          * <p>
          * If there are no header rows when calling this method, the first
          * header row will be created. If there are header rows, the header will
-         * be set on the bottom header row and it will override any existing
-         * header.
+         * be set on the first created header row and it will override any
+         * existing header.
          *
          * @param labelText
          *            the text to be shown at the column header
          * @return this column, for method chaining
          */
         public Column<T> setHeader(String labelText) {
-            getGrid().getColumnLayers().get(0).asHeaderRow().getCell(this)
-                    .setText(labelText);
+            HeaderRow defaultHeaderRow = getGrid().getDefaultHeaderRow();
+            if (defaultHeaderRow == null) {
+                defaultHeaderRow = getGrid().addFirstHeaderRow();
+            }
+            defaultHeaderRow.getCell(this).setText(labelText);
             return this;
         }
 
@@ -586,16 +587,19 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
          * <p>
          * If there are no header rows when calling this method, the first
          * header row will be created. If there are header rows, the header will
-         * be set on the bottom header row and it will override any existing
-         * header.
+         * be set on the first created header row and it will override any
+         * existing header.
          *
          * @param headerComponent
          *            the component to be used in the header of the column
          * @return this column, for method chaining
          */
         public Column<T> setHeader(Component headerComponent) {
-            getGrid().getColumnLayers().get(0).asHeaderRow().getCell(this)
-                    .setComponent(headerComponent);
+            HeaderRow defaultHeaderRow = getGrid().getDefaultHeaderRow();
+            if (defaultHeaderRow == null) {
+                defaultHeaderRow = getGrid().addFirstHeaderRow();
+            }
+            defaultHeaderRow.getCell(this).setComponent(headerComponent);
             return this;
         }
 
@@ -618,48 +622,8 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
         }
 
         @Override
-        protected void setHeaderComponent(Component headerComponent) {
-            /*
-             * Uses the special renderer to take care of the vaadin-grid-sorter.
-             */
-            super.setHeaderRenderer(
-                    new GridSorterComponentRenderer<>(this, headerComponent));
-        }
-
-        /*
-         * This method is invoked only for TemplateRenderers.
-         */
-        @Override
-        protected Rendering<?> renderHeader() {
-            Rendering<?> rendering = super.renderHeader();
-            if (rendering == null) {
-                return null;
-            }
-
-            setBaseHeaderTemplate(headerTemplate.getProperty("innerHTML"));
-            if (isSortable()) {
-                headerTemplate.setProperty("innerHTML",
-                        addGridSorter(rawHeaderTemplate));
-            }
-            return rendering;
-        }
-
-        /*
-         * The original header template is needed for when sorting is enabled or
-         * disabled in a column.
-         */
-        void setBaseHeaderTemplate(String headerTemplate) {
-            rawHeaderTemplate = headerTemplate;
-        }
-
-        /*
-         * Adds the sorting webcomponent markup to an existing template.
-         */
-        String addGridSorter(String templateInnerHtml) {
-            String escapedColumnId = HtmlUtils.escape(columnInternalId);
-            return String.format(
-                    "<vaadin-grid-sorter path='%s'>%s</vaadin-grid-sorter>",
-                    escapedColumnId, templateInnerHtml);
+        protected Column<?> getBottomLevelColumn() {
+            return this;
         }
 
     }
@@ -869,6 +833,7 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
      * layers are in order from innermost to outmost.
      */
     private List<ColumnLayer> columnLayers = new ArrayList<>();
+    private HeaderRow defaultHeaderRow;
 
     /**
      * Creates a new instance, with page size of 50.
@@ -892,6 +857,7 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
         setPageSize(pageSize);
         setSelectionModel(SelectionMode.SINGLE.createModel(this),
                 SelectionMode.SINGLE);
+
         columnLayers.add(new ColumnLayer(this));
     }
 
@@ -1176,7 +1142,7 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
      */
     public HeaderRow prependHeaderRow() {
         if (getHeaderRows().size() == 0) {
-            return columnLayers.get(0).asHeaderRow();
+            return addFirstHeaderRow();
         }
         return insertColumnLayer(columnLayers.size()).asHeaderRow();
     }
@@ -1190,9 +1156,19 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
      */
     public HeaderRow appendHeaderRow() {
         if (getHeaderRows().size() == 0) {
-            return columnLayers.get(0).asHeaderRow();
+            return addFirstHeaderRow();
         }
         return insertInmostColumnLayer(true, false).asHeaderRow();
+    }
+
+    protected HeaderRow addFirstHeaderRow() {
+        defaultHeaderRow = columnLayers.get(0).asHeaderRow();
+        columnLayers.get(0).updateSortingIndicators(true);
+        return defaultHeaderRow;
+    }
+
+    protected HeaderRow getDefaultHeaderRow() {
+        return defaultHeaderRow;
     }
 
     /**
@@ -1282,7 +1258,8 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
         IntStream.range(0, groups.size()).forEach(i -> {
             // Move templates from columns to column-groups
             if (forFooterRow) {
-                groups.get(i).setFooterRenderer(columns.get(i).getFooterRenderer());
+                groups.get(i)
+                        .setFooterRenderer(columns.get(i).getFooterRenderer());
                 columns.get(i).setFooterRenderer(null);
             }
             if (forHeaderRow) {
@@ -1306,6 +1283,12 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
         bottomLayer.setColumns(groups);
 
         columnLayers.add(0, newBottomLayer);
+
+        if (bottomLayer.isHeaderRow()
+                && bottomLayer.asHeaderRow().equals(defaultHeaderRow)) {
+            bottomLayer.updateSortingIndicators(true);
+            newBottomLayer.updateSortingIndicators(false);
+        }
 
         return newBottomLayer;
     }

--- a/src/main/java/com/vaadin/flow/component/grid/GridSorterComponentRenderer.java
+++ b/src/main/java/com/vaadin/flow/component/grid/GridSorterComponentRenderer.java
@@ -19,7 +19,6 @@ import java.util.Optional;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
-import com.vaadin.flow.component.grid.Grid.Column;
 import com.vaadin.flow.data.provider.ComponentDataGenerator;
 import com.vaadin.flow.data.provider.DataGenerator;
 import com.vaadin.flow.data.provider.DataKeyMapper;
@@ -38,7 +37,7 @@ import com.vaadin.flow.dom.Element;
 class GridSorterComponentRenderer<SOURCE>
         extends ComponentRenderer<Component, SOURCE> {
 
-    private final Column<?> column;
+    private final AbstractColumn<?> column;
     private final Component component;
 
     /**
@@ -50,7 +49,8 @@ class GridSorterComponentRenderer<SOURCE>
      * @param component
      *            The component to be used by the renderer
      */
-    public GridSorterComponentRenderer(Column<?> column, Component component) {
+    public GridSorterComponentRenderer(AbstractColumn<?> column,
+            Component component) {
         this.column = column;
         this.component = component;
     }
@@ -99,7 +99,7 @@ class GridSorterComponentRenderer<SOURCE>
          * knows how to add or remove the grid sorter.
          */
         column.setBaseHeaderTemplate(templateInnerHtml);
-        if (column.isSortable()) {
+        if (column.hasSortingIndicators()) {
             templateInnerHtml = column.addGridSorter(templateInnerHtml);
         }
 

--- a/src/main/java/com/vaadin/flow/component/grid/HeaderRow.java
+++ b/src/main/java/com/vaadin/flow/component/grid/HeaderRow.java
@@ -112,6 +112,13 @@ public class HeaderRow extends AbstractRow<HeaderCell> {
      */
     public HeaderCell join(Collection<HeaderCell> cells) {
         Grid<?> grid = layer.getGrid();
+        if (equals(grid.getDefaultHeaderRow())) {
+            throw new UnsupportedOperationException(
+                    "Cells cannot be joined on the first created header row. "
+                            + "This row is used as the default row for setting column "
+                            + "headers and for displaying sorting indicators, so the cells "
+                            + "need to have 1-1 relationship with the columns.");
+        }
         if (!isOutmostRow()) {
             throw new IllegalArgumentException(
                     "Cells can be joined only on the out-most row");

--- a/src/test/java/com/vaadin/flow/component/grid/HeaderFooterTest.java
+++ b/src/test/java/com/vaadin/flow/component/grid/HeaderFooterTest.java
@@ -90,6 +90,26 @@ public class HeaderFooterTest {
     }
 
     @Test
+    public void setHeader_firstHeaderRowCreated() {
+        firstColumn.setHeader("foo");
+        Assert.assertEquals(
+                "There should be one HeaderRow after setting a header for a column",
+                1, grid.getHeaderRows().size());
+        assertRowWrapsLayer(grid.getHeaderRows().get(0),
+                getColumnLayersAndAssertCount(1).get(0));
+    }
+
+    @Test
+    public void setFooter_firstFooterRowCreated() {
+        firstColumn.setFooter("foo");
+        Assert.assertEquals(
+                "There should be one FooterRow after setting a footer for a column",
+                1, grid.getFooterRows().size());
+        assertRowWrapsLayer(grid.getFooterRows().get(0),
+                getColumnLayersAndAssertCount(1).get(0));
+    }
+
+    @Test
     public void appendHeaderRows_firstOnTop() {
         HeaderRow first = grid.appendHeaderRow();
         HeaderRow second = grid.appendHeaderRow();

--- a/src/test/java/com/vaadin/flow/component/grid/demo/GridView.java
+++ b/src/test/java/com/vaadin/flow/component/grid/demo/GridView.java
@@ -930,13 +930,17 @@ public class GridView extends DemoView {
         // source-example-heading: Grid Basic Features Demo
         DecimalFormat dollarFormat = new DecimalFormat("$#,##0.00");
         Grid<CompanyBudgetHistory> grid = new Grid<>();
+
         ListDataProvider<CompanyBudgetHistory> list = CompanyBudgetHistory
                 .getBudgetDataProvider(baseYear, numberOfYears);
+        grid.setDataProvider(list);
 
         grid.setColumnReorderingAllowed(true);
 
-        grid.setDataProvider(list);
-        grid.addColumn(CompanyBudgetHistory::getCompany).setHeader("Company");
+        Column<CompanyBudgetHistory> companyNameColumn = grid
+                .addColumn(CompanyBudgetHistory::getCompany)
+                .setHeader("Company");
+        companyNameColumn.setWidth("200px");
 
         grid.setSelectionMode(SelectionMode.SINGLE);
 
@@ -980,6 +984,26 @@ public class GridView extends DemoView {
             topHeader.join(firstHalfColumn, secondHalfColumn)
                     .setText(year + "");
         });
+
+        HeaderRow filteringHeader = grid.appendHeaderRow();
+
+        TextField filteringField = new TextField();
+        filteringField.addValueChangeListener(event -> {
+            list.setFilter(CompanyBudgetHistory::getCompany, company -> {
+                if (company == null) {
+                    return false;
+                }
+                String companyLower = company.toLowerCase(Locale.ENGLISH);
+                String filterLower = event.getValue()
+                        .toLowerCase(Locale.ENGLISH);
+                return companyLower.contains(filterLower);
+            });
+        });
+        filteringField.setPlaceholder("Filter");
+        filteringField.setWidth("100%");
+
+        filteringHeader.getCell(companyNameColumn).setComponent(filteringField);
+
         // end-source-example
 
         grid.setId("grid-basic-feature");

--- a/src/test/java/com/vaadin/flow/component/grid/it/GridHeaderFooterRowPage.java
+++ b/src/test/java/com/vaadin/flow/component/grid/it/GridHeaderFooterRowPage.java
@@ -22,6 +22,7 @@ import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.grid.Grid.Column;
 import com.vaadin.flow.component.grid.Grid.SelectionMode;
 import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Label;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.function.ValueProvider;
 import com.vaadin.flow.router.Route;
@@ -42,7 +43,6 @@ public class GridHeaderFooterRowPage extends Div {
         grid.setItems(Arrays.asList("Item 1", "Item 2", "Item 3"));
         Column<String> column = grid.addColumn(ValueProvider.identity());
         add(grid);
-
         NativeButton button = new NativeButton("Prepend header", event -> grid
                 .prependHeaderRow().getCell(column).setText("" + (counter++)));
         button.setId("prepend-header");
@@ -81,6 +81,25 @@ public class GridHeaderFooterRowPage extends Div {
         button = new NativeButton("Disable selection",
                 event -> grid.setSelectionMode(SelectionMode.NONE));
         button.setId("disable-selection");
+        add(button);
+
+        button = new NativeButton("Set components for headers",
+                event -> grid.getHeaderRows().stream()
+                        .flatMap(row -> row.getCells().stream())
+                        .forEach(cell -> cell.setComponent(new Label("foo"))));
+        button.setId("set-components-for-headers");
+        add(button);
+
+        button = new NativeButton("Set text for headers",
+                event -> grid.getHeaderRows().stream()
+                        .flatMap(row -> row.getCells().stream())
+                        .forEach(cell -> cell.setText("bar")));
+        button.setId("set-texts-for-headers");
+        add(button);
+
+        button = new NativeButton("Column::setHeader",
+                event -> column.setHeader("" + (counter++)));
+        button.setId("column-set-header");
         add(button);
     }
 

--- a/src/test/java/com/vaadin/flow/component/grid/it/GridViewIT.java
+++ b/src/test/java/com/vaadin/flow/component/grid/it/GridViewIT.java
@@ -600,15 +600,20 @@ public class GridViewIT extends TabbedComponentDemoTest {
     }
 
     @Test
-    public void basicFeature() {
+    public void basicFeatures() {
         openTabAndCheckForErrors("basic-features");
         GridElement grid = $(GridElement.class).id("grid-basic-feature");
         scrollToElement(grid);
         waitUntil(driver -> grid.getAllColumns().size() == 11);
 
-        Assert.assertEquals(
-                "The first header should be \"Company\" in the Grid", "Company",
-                grid.getHeaderCell(0).getInnerHTML());
+        TestBenchElement filteringField = grid
+                .findElement(By.tagName("vaadin-text-field"));
+        filteringField.sendKeys("sek");
+
+        Assert.assertThat(
+                "The first company name should contain the applied filter string",
+                grid.getCell(0, 0).getInnerHTML().toLowerCase(),
+                CoreMatchers.containsString("sek"));
     }
 
     @Test


### PR DESCRIPTION
for having sorting indicators and as the target of Column::setHeader.

Filtering row is added to the "Basic features" demo now that the sorting indicators don't go always to the bottom row.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-flow/181)
<!-- Reviewable:end -->
