### PR TITLE
Fix removing empty column-groups after initial rendering

### DIFF
--- a/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -1800,23 +1800,23 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
     }
 
     private void removeColumnAndColumnGroupsIfNeeded(Column<?> column) {
-        Element parent = column.getElement().getParent();
-        parent.removeChild(column.getElement());
+        Component parent = column.getParent().get();
+        parent.getElement().removeChild(column.getElement());
         columnLayers.get(0).removeColumn(column);
-        if (!parent.equals(getElement())) {
-            removeEmptyColumnGroups(parent, 1);
+        if (!parent.equals(this)) {
+            removeEmptyColumnGroups((ColumnGroup) parent, 1);
         }
     }
 
-    private void removeEmptyColumnGroups(Element columnGroup,
+    private void removeEmptyColumnGroups(ColumnGroup columnGroup,
             int columnLayerIndex) {
-        Element parent = columnGroup.getParent();
-        if (columnGroup.getChildCount() == 0) {
-            parent.removeChild(columnGroup);
-            columnLayers.get(columnLayerIndex).removeColumn(
-                    (AbstractColumn<?>) columnGroup.getComponent().get());
-            if (!parent.equals(getElement())) {
-                removeEmptyColumnGroups(parent, columnLayerIndex + 1);
+        Component parent = columnGroup.getParent().get();
+        if (columnGroup.getChildColumns().size() == 0) {
+            parent.getElement().removeChild(columnGroup.getElement());
+            columnLayers.get(columnLayerIndex).removeColumn(columnGroup);
+            if (!parent.equals(this)) {
+                removeEmptyColumnGroups((ColumnGroup) parent,
+                        columnLayerIndex + 1);
             }
         }
     }

--- a/src/test/java/com/vaadin/flow/component/grid/HeaderFooterTest.java
+++ b/src/test/java/com/vaadin/flow/component/grid/HeaderFooterTest.java
@@ -593,13 +593,13 @@ public class HeaderFooterTest {
         grid.removeColumn(secondColumn);
 
         List<List<Element>> layers = getColumnLayersAndAssertCount(1);
-        assertRowWrapsLayer(header, layers.get(0));
-        assertRowWrapsLayer(footer, layers.get(0));
+        assertRowWrapsLayer(header, layers.get(0), 2);
+        assertRowWrapsLayer(footer, layers.get(0), 2);
 
         grid.removeColumn(thirdColumn);
         layers = getColumnLayersAndAssertCount(1);
-        assertRowWrapsLayer(header, layers.get(0));
-        assertRowWrapsLayer(footer, layers.get(0));
+        assertRowWrapsLayer(header, layers.get(0), 1);
+        assertRowWrapsLayer(footer, layers.get(0), 1);
     }
 
     @Test

--- a/src/test/java/com/vaadin/flow/component/grid/it/GridHeaderFooterRowIT.java
+++ b/src/test/java/com/vaadin/flow/component/grid/it/GridHeaderFooterRowIT.java
@@ -189,6 +189,25 @@ public class GridHeaderFooterRowIT extends AbstractComponentIT {
         assertHeaderHasGridSorter(1);
     }
 
+    @Test
+    public void addHeadersAndFooters_removeColumn_columnGroupsRemoved() {
+        clickButton("prepend-header");
+        clickButton("append-footer");
+        clickButton("prepend-header");
+        clickButton("append-footer");
+
+        clickButton("remove-column");
+
+        List<WebElement> columns = grid
+                .findElements(By.tagName("vaadin-grid-column"));
+        List<WebElement> groups = grid
+                .findElements(By.tagName("vaadin-grid-column-group"));
+
+        Assert.assertEquals(
+                "There should be no column or column-group elements after removing the only column",
+                0, columns.size() + groups.size());
+    }
+
     private void assertHeaderComponentsAreRendered() {
         List<String> headerContents = getHeaderContents();
         headerContents.forEach(content -> Assert.assertThat(

--- a/src/test/java/com/vaadin/flow/component/grid/it/GridHeaderFooterRowPage.java
+++ b/src/test/java/com/vaadin/flow/component/grid/it/GridHeaderFooterRowPage.java
@@ -106,6 +106,11 @@ public class GridHeaderFooterRowPage extends Div {
         button.setId("column-set-header");
         add(button);
 
+        button = new NativeButton("Remove column",
+                event -> grid.removeColumn(column));
+        button.setId("remove-column");
+        add(button);
+
         getElement().appendChild(new Element("hr"));
         /*
          * Another grid for joining cells


### PR DESCRIPTION
The logic for checking empty column-groups was to check that
childCount==0, but that worked only before first rendering (before
templates were attached beforeClientResponse). Now it checks if there
are no column or column-group children.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-flow/202)
<!-- Reviewable:end -->
