### PR TITLE
Use alphabetical order for bean-grid columns by default

### DIFF
--- a/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -877,8 +877,12 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
      * {@link Column#setKey(String) column keys} and the property captions will
      * be used as the {@link Column#setHeader(String) column headers}.
      * <p>
-     * You can add columns for nested properties of the bean with
-     * {@link #addColumn(String)}.
+     * By default, only the direct properties of the bean are included and they
+     * will be in alphabetical order. Use {@link Grid#setColumns(String...)} to
+     * define which properties to include and in which order. You can also add a
+     * column for an individual property with {@link #addColumn(String)}. Both
+     * of these methods support also sub-properties with dot-notation, eg.
+     * <code>"property.nestedProperty"</code>.
      *
      * @param beanType
      *            the bean type to use, not <code>null</code>
@@ -888,7 +892,8 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
         Objects.requireNonNull(beanType, "Bean type can't be null");
         propertySet = BeanPropertySet.get(beanType);
         propertySet.getProperties()
-                .filter(property -> !property.isSubProperty())
+                .filter(property -> !property.isSubProperty()).sorted((prop1,
+                        prop2) -> prop1.getName().compareTo(prop2.getName()))
                 .forEach(this::addColumn);
     }
 

--- a/src/test/java/com/vaadin/flow/component/grid/BeanGridTest.java
+++ b/src/test/java/com/vaadin/flow/component/grid/BeanGridTest.java
@@ -36,9 +36,9 @@ public class BeanGridTest {
     }
 
     @Test
-    public void beanGrid_columnsForPropertiesAddedWithCorrectKeys() {
-        String[] expectedKeys = new String[] { "born", "name", "friend",
-                "grades", "items" };
+    public void beanGrid_columnsForPropertiesAddedWithCorrectKeysInAlphabeticalOrder() {
+        String[] expectedKeys = new String[] { "born", "friend", "grades",
+                "items", "name" };
         Object[] keys = grid.getColumns().stream().map(Column::getKey)
                 .toArray();
 

--- a/src/test/java/com/vaadin/flow/component/grid/it/GridViewIT.java
+++ b/src/test/java/com/vaadin/flow/component/grid/it/GridViewIT.java
@@ -544,8 +544,8 @@ public class GridViewIT extends TabbedComponentDemoTest {
                 grid.findElements(By.tagName("vaadin-grid-column")).size());
 
         Assert.assertEquals("Address", grid.getHeaderCell(0).getText());
-        Assert.assertEquals("Name", grid.getHeaderCell(1).getText());
-        Assert.assertEquals("Age", grid.getHeaderCell(2).getText());
+        Assert.assertEquals("Age", grid.getHeaderCell(1).getText());
+        Assert.assertEquals("Name", grid.getHeaderCell(2).getText());
         Assert.assertEquals("Postal Code", grid.getHeaderCell(3).getText());
     }
 


### PR DESCRIPTION
and improve javadocs of the bean-grid constructor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-flow/217)
<!-- Reviewable:end -->
