### PR TITLE
Enable IT test for clicking a button inside Grid via keyboard

### DIFF
--- a/src/test/java/com/vaadin/flow/component/grid/it/ButtonInGridIT.java
+++ b/src/test/java/com/vaadin/flow/component/grid/it/ButtonInGridIT.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.component.grid.it;
 
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
@@ -30,15 +29,6 @@ import com.vaadin.flow.testutil.TestPath;
 public class ButtonInGridIT extends AbstractComponentIT {
 
     @Test
-    @Ignore
-    /**
-     * The test is disabled due #4268. The test is for grid#122 (which is
-     * actually an issue in the flow-component-renderer inside flow-data
-     * module).
-     *
-     * At the moment the bug is not fixed. So the test fails. Should be enabled
-     * back once the gird#122 is fixed.
-     */
     public void pressButtonUsingKeyboard() {
         open();
 


### PR DESCRIPTION
A part of fix for #122

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-flow/227)
<!-- Reviewable:end -->
