### PR TITLE
Fixed component renderer content not being updated in TreeGrid

### DIFF
--- a/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -239,6 +239,21 @@ window.Vaadin.Flow.gridConnector = {
     }
     grid.addEventListener('sorter-changed', sorterChangeListener);
 
+    grid._updateItem = function(row, item) {
+      Vaadin.GridElement.prototype._updateItem.call(grid, row, item);
+
+      // make sure that component renderers are updated
+      Array.from(row.children).forEach(cell => {
+        if(cell._instance && cell._instance.children) {
+          Array.from(cell._instance.children).forEach(content => {
+            if(content._attachRenderedComponentIfAble) {
+              content._attachRenderedComponentIfAble();
+            }
+          });
+        }
+      });
+    }
+
     grid._expandedInstanceChangedCallback = function(inst, value) {
       if (inst.item == undefined) {
         return;
@@ -543,5 +558,6 @@ window.Vaadin.Flow.gridConnector = {
         throw 'Attempted to set an invalid selection mode';
       }
     }
+
   }
 }

--- a/src/test/java/com/vaadin/flow/component/grid/it/ButtonInGridIT.java
+++ b/src/test/java/com/vaadin/flow/component/grid/it/ButtonInGridIT.java
@@ -29,7 +29,6 @@ import com.vaadin.flow.testutil.TestPath;
 @TestPath("vaadin-button-inside-grid")
 public class ButtonInGridIT extends AbstractComponentIT {
 
-    @Ignore
     @Test
     @Ignore
     /**

--- a/src/test/java/com/vaadin/flow/component/grid/it/ButtonInGridIT.java
+++ b/src/test/java/com/vaadin/flow/component/grid/it/ButtonInGridIT.java
@@ -29,6 +29,7 @@ import com.vaadin.flow.testutil.TestPath;
 @TestPath("vaadin-button-inside-grid")
 public class ButtonInGridIT extends AbstractComponentIT {
 
+    @Ignore
     @Test
     @Ignore
     /**

--- a/src/test/java/com/vaadin/flow/component/grid/testbench/TreeGridElement.java
+++ b/src/test/java/com/vaadin/flow/component/grid/testbench/TreeGridElement.java
@@ -123,7 +123,7 @@ public class TreeGridElement extends GridElement {
      * @param columnIndex
      *            0-based index of the column
      * @param searchContentBy
-     *            Search for specific content
+     *            Search for specific content. May be null.
      * @return {@code true} if this cell has the component renderer visible with
      *         the optional search locator
      */

--- a/src/test/java/com/vaadin/flow/component/grid/testbench/TreeGridElement.java
+++ b/src/test/java/com/vaadin/flow/component/grid/testbench/TreeGridElement.java
@@ -15,6 +15,9 @@
  */
 package com.vaadin.flow.component.grid.testbench;
 
+import java.util.Optional;
+
+import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 
@@ -113,6 +116,34 @@ public class TreeGridElement extends GridElement {
 
     /**
      * Check whether the given indices correspond to a cell that contains a
+     * visible component renderer with the optional search locator {@link By}.
+     *
+     * @param rowIndex
+     *            0-based row index
+     * @param columnIndex
+     *            0-based index of the column
+     * @param searchContentBy
+     *            Search for specific content
+     * @return {@code true} if this cell has the component renderer visible with
+     *         the optional search locator
+     */
+    public boolean hasComponentRenderer(int rowIndex, int columnIndex,
+            By searchContentBy) {
+        try {
+            WebElement rendererElement = getComponentRendererElement(rowIndex,
+                    columnIndex);
+            return rendererElement != null && rendererElement.isDisplayed()
+                    && Optional.ofNullable(searchContentBy)
+                            .map(by -> rendererElement.findElement(by))
+                            .map(WebElement::isDisplayed)
+                            .orElse(searchContentBy == null);
+        } catch (NoSuchElementException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Check whether the given indices correspond to a cell that contains a
      * visible hierarchy toggle element.
      *
      * @param rowIndex
@@ -147,6 +178,24 @@ public class TreeGridElement extends GridElement {
     public WebElement getExpandToggleElement(int rowIndex, int hierarchyColumnIndex) {
         return getCell(rowIndex, hierarchyColumnIndex)
                 .$("vaadin-grid-tree-toggle").first();
+
+    }
+
+    /**
+     * Gets the 'flow-component-renderer' element for the given row.
+     *
+     * @param rowIndex
+     *            0-based row index
+     * @param columnIndex
+     *            0-based index of the column
+     * @return the component renderer element
+     * @throws NoSuchElementException
+     *             if there is no component renderer element for this row
+     */
+    public WebElement getComponentRendererElement(int rowIndex,
+            int columnIndex) {
+        return getCell(rowIndex, columnIndex).$("flow-component-renderer")
+                .first();
 
     }
 

--- a/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridComponentRendererIT.java
+++ b/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridComponentRendererIT.java
@@ -1,0 +1,60 @@
+package com.vaadin.flow.component.treegrid.it;
+
+import java.util.stream.IntStream;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import com.vaadin.flow.testutil.TestPath;
+
+@TestPath("treegrid-component-renderer")
+public class TreeGridComponentRendererIT extends AbstractTreeGridIT {
+
+    @Before
+    public void before() {
+        open();
+        setupTreeGrid();
+    }
+
+    @Test
+    public void treegridComponentRenderer_expandCollapseExpand_renderersShows() {
+        getTreeGrid().expandWithClick(0);
+
+        assertCellTexts(0, 0, "Granddad 0");
+        assertCellTexts(1, 0, "Dad 0/0");
+        assertCellTexts(2, 0, "Dad 0/1");
+        assertCellTexts(3, 0, "Dad 0/2");
+        assertCellTexts(4, 0, "Granddad 1");
+        assertCellTexts(5, 0, "Granddad 2");
+
+        assertAllRowsHasTextField(6);
+
+        getTreeGrid().collapseWithClick(0);
+
+        assertCellTexts(0, 0, "Granddad 0");
+        assertCellTexts(1, 0, "Granddad 1");
+        assertCellTexts(2, 0, "Granddad 2");
+
+        assertAllRowsHasTextField(3);
+
+        getTreeGrid().expandWithClick(0);
+
+        assertCellTexts(0, 0, "Granddad 0");
+        assertCellTexts(1, 0, "Dad 0/0");
+        assertCellTexts(2, 0, "Dad 0/1");
+        assertCellTexts(3, 0, "Dad 0/2");
+        assertCellTexts(4, 0, "Granddad 1");
+        assertCellTexts(5, 0, "Granddad 2");
+
+        assertAllRowsHasTextField(6);
+    }
+
+    private void assertAllRowsHasTextField(int expectedRowCount) {
+        Assert.assertEquals(expectedRowCount, getTreeGrid().getRowCount());
+        IntStream.range(0, getTreeGrid().getRowCount()).forEach(
+                i -> Assert.assertTrue(getTreeGrid().hasComponentRenderer(i, 1,
+                        By.tagName("vaadin-text-field"))));
+    }
+}

--- a/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridComponentRendererPage.java
+++ b/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridComponentRendererPage.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License. 
+ */
+package com.vaadin.flow.component.treegrid.it;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.textfield.TextField;
+import com.vaadin.flow.component.treegrid.TreeGrid;
+import com.vaadin.flow.data.provider.hierarchy.TreeData;
+import com.vaadin.flow.data.provider.hierarchy.TreeDataProvider;
+import com.vaadin.flow.data.renderer.ComponentRenderer;
+import com.vaadin.flow.router.Route;
+
+import static com.vaadin.flow.component.treegrid.it.TreeGridHugeTreePage.addItems;
+import static com.vaadin.flow.component.treegrid.it.TreeGridHugeTreePage.addRootItems;
+
+@Route("treegrid-component-renderer")
+public class TreeGridComponentRendererPage extends Div {
+
+    public TreeGridComponentRendererPage() {
+        setSizeFull();
+        getStyle().set("display", "flex");
+        getStyle().set("flex-direction", "column");
+
+        TreeGrid<String> grid = new TreeGrid<>();
+        grid.setWidth("100%");
+        grid.getStyle().set("flex", "1");
+        grid.addHierarchyColumn(String::toString).setHeader("Header A")
+                .setId("string");
+
+        ComponentRenderer<TextField, String> componentRenderer = new ComponentRenderer<TextField, String>(
+                () -> new TextField(), (component, item) -> {
+                    component.setReadOnly(true);
+                    component.setValue(item);
+                });
+        grid.addColumn(componentRenderer).setHeader("Header B");
+
+        TreeData<String> data = new TreeData<>();
+        final Map<String, String> parentPathMap = new HashMap<>();
+
+        addRootItems("Granddad", 3, data, parentPathMap).forEach(
+                granddad -> addItems("Dad", 3, granddad, data, parentPathMap)
+                        .forEach(dad -> addItems("Son", 100, dad, data,
+                                parentPathMap)));
+
+        grid.setDataProvider(new TreeDataProvider<String>(data));
+
+        add(grid);
+    }
+
+}


### PR DESCRIPTION
Problem occurs when expanding item. Only expanded visible items are updated properly because those are new items. Already existing visible components may be lost when their row index changes. Call to _attachRenderedComponentIfAble function explicitly in _updateItem makes sure that component is re-attached.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-flow/232)
<!-- Reviewable:end -->
