### PR TITLE
Observe changes in _previousSorters instead of using an eventListener.

### DIFF
--- a/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -371,7 +371,7 @@ window.Vaadin.Flow.gridConnector = {
       }
     }
 
-    const sorterChangeListener = function(event) {
+    const sorterChangeListener = function() {
       grid.$server.sortersChanged(grid._sorters.map(function(sorter) {
         return {
           path: sorter.path,
@@ -379,7 +379,7 @@ window.Vaadin.Flow.gridConnector = {
         };
       }));
     }
-    grid.addEventListener('sorter-changed', sorterChangeListener);
+    grid._createPropertyObserver("_previousSorters", sorterChangeListener);
 
     grid._updateItem = function(row, item) {
       Vaadin.GridElement.prototype._updateItem.call(grid, row, item);


### PR DESCRIPTION
This way we update the serverside sorting always after the
sorter-changed event has been handled by grid.

Fixes #188

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-flow/249)
<!-- Reviewable:end -->
