### PR TITLE
Add API for getting ContextMenu target item

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-context-menu-flow</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <version>1.10.19</version>

--- a/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -734,5 +734,27 @@ window.Vaadin.Flow.gridConnector = {
       }
     }
 
+    const contextMenuListener = function(e) {
+      const overlay = document.getElementsByTagName('vaadin-context-menu-overlay')[0];
+      if (overlay && !overlay.isHandledByGridConnector) {
+        overlay.isHandledByGridConnector = true;
+        overlay.addEventListener('opened-changed', function(e) {
+          grid.$server.updateContextMenuOpened(overlay.opened);
+        });
+        grid.$server.updateContextMenuOpened(true);
+      }
+
+      // https://github.com/vaadin/vaadin-grid/issues/1318
+      const path = e.composedPath();
+      const cell = path[path.indexOf(grid.$.table) - 3]; // <td> element in shadow dom
+      var key;
+      if (cell && cell._instance.item) {
+        key = cell._instance.item.key;
+      }
+      grid.$server.updateContextMenuTargetItem(key);
+    }
+
+    grid.addEventListener('vaadin-contextmenu', contextMenuListener);
+    grid.addEventListener('click', contextMenuListener);
   }
 }

--- a/src/test/java/com/vaadin/flow/component/grid/demo/GridView.java
+++ b/src/test/java/com/vaadin/flow/component/grid/demo/GridView.java
@@ -42,6 +42,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.checkbox.Checkbox;
+import com.vaadin.flow.component.contextmenu.ContextMenu;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.grid.Grid.Column;
 import com.vaadin.flow.component.grid.Grid.SelectionMode;
@@ -369,6 +370,7 @@ public class GridView extends DemoView {
         createDisabledGrid();
         createBasicTreeGridUsage();
         createLazyLoadingTreeGridUsage();
+        createContextMenu();
 
         addCard("Grid example model",
                 new Label("These objects are used in the examples above"));
@@ -1208,6 +1210,40 @@ public class GridView extends DemoView {
                                 null, null))
                         .collect(Collectors.toList()),
                         grid, message));
+    }
+
+    private void createContextMenu() {
+        // begin-source-example
+        // source-example-heading: Using ContextMenu With Grid
+        Grid<Person> grid = new Grid<>();
+        grid.setItems(getItems());
+
+        grid.addColumn(Person::getName).setHeader("Name");
+        grid.addColumn(Person::getAge).setHeader("Age");
+
+        ContextMenu contextMenu = new ContextMenu(grid);
+        contextMenu.addItem("Update", event -> {
+            Person person = grid.getContextMenuTargetItem();
+            person.setName(person.getName() + " Updated");
+
+            ListDataProvider<Person> dataProvider = (ListDataProvider<Person>) grid
+                    .getDataProvider();
+            dataProvider.refreshItem(person);
+        });
+        contextMenu.addItem("Remove", event -> {
+            Person person = grid.getContextMenuTargetItem();
+
+            ListDataProvider<Person> dataProvider = (ListDataProvider<Person>) grid
+                    .getDataProvider();
+            dataProvider.getItems().remove(person);
+            dataProvider.refreshAll();
+        });
+
+        // end-source-example
+        grid.setId("context-menu-grid");
+
+        addCard("Context Menu", "Using ContextMenu With Grid", grid,
+                contextMenu);
     }
 
     private <T> Component[] withTreeGridToggleButtons(List<T> roots,


### PR DESCRIPTION
This is implemented by adding a method to Grid which throws an exception
if there is no opened ContextMenu present. The API is not optimal, as it
would be nice to get the target item from the ContextMenu's click
events, but this is done to avoid having compile dependencies between Grid and
ContextMenu.