### PR TITLE
Add javadoc to Renderer getters

### DIFF
--- a/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -336,6 +336,10 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
         /**
          * Get the renderer used for this column.
          *
+         * Note: Mutating the renderer after the Grid has been rendered
+         * on the client will not change the column, and can lead to
+         * undefined behavior.
+         *
          * @return the renderer used for this column, should never be {@code null}
          */
         public Renderer<T> getRenderer() {

--- a/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -298,10 +298,11 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
          * @param columnId
          *            unique identifier of this column
          * @param renderer
-         *            the renderer to use in this column
+         *            the renderer to use in this column, must not be {@code null}
          */
         public Column(Grid<T> grid, String columnId, Renderer<T> renderer) {
             super(grid);
+            Objects.requireNonNull(renderer);
             this.columnInternalId = columnId;
             this.renderer = renderer;
 
@@ -335,7 +336,7 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
         /**
          * Get the renderer used for this column.
          *
-         * @return the renderer used for this column
+         * @return the renderer used for this column, should never be {@code null}
          */
         public Renderer<T> getRenderer() {
             return renderer;

--- a/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -288,6 +288,8 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
 
         private Registration columnDataGeneratorRegistration;
 
+        private Renderer<T> renderer;
+
         /**
          * Constructs a new Column for use inside a Grid.
          *
@@ -301,6 +303,7 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
         public Column(Grid<T> grid, String columnId, Renderer<T> renderer) {
             super(grid);
             this.columnInternalId = columnId;
+            this.renderer = renderer;
 
             comparator = (a, b) -> 0;
 
@@ -327,6 +330,15 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
 
         protected String getInternalId() {
             return columnInternalId;
+        }
+
+        /**
+         * Get the renderer used for this column.
+         *
+         * @return the renderer used for this column
+         */
+        public Renderer<T> getRenderer() {
+            return renderer;
         }
 
         /**

--- a/src/test/java/com/vaadin/flow/component/grid/GridColumnTest.java
+++ b/src/test/java/com/vaadin/flow/component/grid/GridColumnTest.java
@@ -175,7 +175,7 @@ public class GridColumnTest {
 
     @Test
     public void testRenderer() {
-        Assert.assertNotNull(renderer);
+        assert renderer!= null;
         Assert.assertEquals(renderer, fourthColumn.getRenderer());
     }
     private void expectNullPointerException(String message) {

--- a/src/test/java/com/vaadin/flow/component/grid/GridColumnTest.java
+++ b/src/test/java/com/vaadin/flow/component/grid/GridColumnTest.java
@@ -21,9 +21,13 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.grid.Grid.Column;
+import com.vaadin.flow.component.html.Label;
 import com.vaadin.flow.data.provider.SortDirection;
+import com.vaadin.flow.data.renderer.IconRenderer;
 import com.vaadin.flow.function.SerializableComparator;
+import com.vaadin.flow.function.SerializableFunction;
 
 public class GridColumnTest {
 
@@ -31,6 +35,9 @@ public class GridColumnTest {
     Column<String> firstColumn;
     Column<String> secondColumn;
     Column<String> thirdColumn;
+    Column<String> fourthColumn;
+
+    IconRenderer<String> renderer;
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
@@ -41,6 +48,8 @@ public class GridColumnTest {
         firstColumn = grid.addColumn(str -> str);
         secondColumn = grid.addColumn(str -> str);
         thirdColumn = grid.addColumn(str -> str);
+        renderer = new IconRenderer<String>(generator -> new Label(":D"));
+        fourthColumn = grid.addColumn(renderer);
     }
 
     @Test
@@ -164,6 +173,11 @@ public class GridColumnTest {
                 -1, result);
     }
 
+    @Test
+    public void testRenderer() {
+        Assert.assertNotNull(renderer);
+        Assert.assertEquals(renderer, fourthColumn.getRenderer());
+    }
     private void expectNullPointerException(String message) {
         thrown.expect(NullPointerException.class);
         thrown.expectMessage(message);


### PR DESCRIPTION
Added a javadoc comment saying `getRenderer` return value shouldn't be modified after Grid has been rendered
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-flow/254)
<!-- Reviewable:end -->
