### PR TITLE
Observe changes in _previousSorters instead of using an eventListener. ( #249)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,11 @@
 This project is the Component wrapper implementation of [`<vaadin-grid>`](https://github.com/vaadin/vaadin-grid) element
 for use from the server side with [Vaadin Flow](https://github.com/vaadin/flow).
 
-This branch is Vaadin 10 compatible. See other branches for other framework versions:
-* master branch is Vaadin 11 (Flow version 1.1)
-* 1.0 branch is Vaadin 10 (Flow version 1.0)
+
+This branch is Vaadin 11 compatible. See other branches for other framework versions:
+* master branch is Vaadin 11 compatible (Flow version 1.1)
+* 1.0 branch is Vaadin 10 compatible (Flow version 1.0)
+* 1.1 branch is Vaadin 10 compatible with TreeGrid (Flow version 1.0)
 
 ## Running the component demo
 Run from the command line:

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 This project is the Component wrapper implementation of [`<vaadin-grid>`](https://github.com/vaadin/vaadin-grid) element
 for use from the server side with [Vaadin Flow](https://github.com/vaadin/flow).
 
+This branch is Vaadin 10 compatible. See other branches for other framework versions:
+* master branch is Vaadin 11 (Flow version 1.1)
+* 1.0 branch is Vaadin 10 (Flow version 1.0)
+
 ## Running the component demo
 Run from the command line:
 - `mvn jetty:run -PrunTests`

--- a/pom.xml
+++ b/pom.xml
@@ -31,18 +31,71 @@
         <dependency>
             <groupId>org.webjars.bowergithub.vaadin</groupId>
             <artifactId>vaadin-grid</artifactId>
-            <version>5.0.4</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.webjars.bowergithub.polymerelements</groupId>
-                    <artifactId>iron-flex-layout</artifactId>
-                </exclusion>
-            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.webjars.bowergithub.polymerelements</groupId>
+            <artifactId>iron-scroll-target-behavior</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.webjars.bowergithub.vaadin</groupId>
+            <artifactId>vaadin-element-mixin</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.webjars.bowergithub.vaadin</groupId>
+            <artifactId>vaadin-usage-statistics</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.webjars.bowergithub.vaadin</groupId>
+            <artifactId>vaadin-development-mode-detector</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.webjars.bowergithub.vaadin</groupId>
+            <artifactId>vaadin-lumo-styles</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.webjars.bowergithub.polymerelements</groupId>
+            <artifactId>iron-icon</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.webjars.bowergithub.polymerelements</groupId>
+            <artifactId>iron-meta</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.webjars.bowergithub.polymerelements</groupId>
+            <artifactId>iron-iconset-svg</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.webjars.bowergithub.polymerelements</groupId>
+            <artifactId>iron-resizable-behavior</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.webjars.bowergithub.polymerelements</groupId>
+            <artifactId>iron-a11y-keys-behavior</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.webjars.bowergithub.vaadin</groupId>
+            <artifactId>vaadin-checkbox</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.webjars.bowergithub.vaadin</groupId>
+            <artifactId>vaadin-control-state-mixin</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.webjars.bowergithub.vaadin</groupId>
+            <artifactId>vaadin-themable-mixin</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.webjars.bowergithub.polymerelements</groupId>
+            <artifactId>iron-a11y-announcer</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.webjars.bowergithub.vaadin</groupId>
+            <artifactId>vaadin-text-field</artifactId>
         </dependency>
         <dependency>
             <groupId>org.webjars.bowergithub.polymerelements</groupId>
             <artifactId>iron-flex-layout</artifactId>
-            <version>2.0.3</version>
         </dependency>
 
         <dependency>
@@ -140,6 +193,19 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-radio-button-flow</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.webjars.bowergithub.polymerelements</groupId>
+                    <artifactId>iron-flex-layout</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <version>1.10.19</version>
@@ -177,5 +243,5 @@
             </dependencies>
         </profile>
     </profiles>
-    
+
 </project>

--- a/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -875,7 +875,9 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
      * properties. The property-values of the bean will be converted to Strings.
      * Full names of the properties will be used as the
      * {@link Column#setKey(String) column keys} and the property captions will
-     * be used as the {@link Column#setHeader(String) column headers}.
+     * be used as the {@link Column#setHeader(String) column headers}. The
+     * generated columns will be sortable by default, if the property is
+     * {@link Comparable}.
      * <p>
      * By default, only the direct properties of the bean are included and they
      * will be in alphabetical order. Use {@link Grid#setColumns(String...)} to
@@ -1075,9 +1077,6 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
     }
 
     /**
-     * <strong>Note:</strong> This method can only be used for a Grid created
-     * from a bean type with {@link #Grid(Class)}.
-     * <p>
      * Adds a new column for the given property name. The property values are
      * converted to Strings in the grid cells. The property's full name will be
      * used as the {@link Column#setKey(String) column key} and the property
@@ -1086,6 +1085,13 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
      * <p>
      * You can add columns for nested properties with dot notation, eg.
      * <code>"property.nestedProperty"</code>
+     * <p>
+     * If the property is {@link Comparable}, the created column is sortable by
+     * default. This can be changed with the {@link Column#setSortable(boolean)}
+     * method.
+     * <p>
+     * <strong>Note:</strong> This method can only be used for a Grid created
+     * from a bean type with {@link #Grid(Class)}.
      *
      * @param propertyName
      *            the property name of the new column, not <code>null</code>
@@ -1113,12 +1119,17 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
                 item -> runPropertyValueGetter(property, item))
                         .setHeader(property.getCaption());
         try {
-            return column.setKey(property.getName());
+            column.setKey(property.getName());
         } catch (IllegalArgumentException exception) {
             throw new IllegalArgumentException(
                     "Multiple columns for the same property: "
                             + property.getName());
         }
+
+        if (Comparable.class.isAssignableFrom(property.getType())) {
+            column.setSortable(true);
+        }
+        return column;
     }
 
     private Object runPropertyValueGetter(PropertyDefinition<T, ?> property,
@@ -1127,9 +1138,6 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
     }
 
     /**
-     * <strong>Note:</strong> This method can only be used for a Grid created
-     * from a bean type with {@link #Grid(Class)}.
-     * <p>
      * Sets the columns and their order based on the given properties.
      * <p>
      * This is a shortcut for removing all columns and then calling
@@ -1139,6 +1147,9 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
      * <code>"property.nestedProperty"</code>
      * <p>
      * Note that this also resets the headers and footers.
+     * <p>
+     * <strong>Note:</strong> This method can only be used for a Grid created
+     * from a bean type with {@link #Grid(Class)}.
      * 
      * @param propertyNames
      *            the properties to create columns for

--- a/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -244,8 +244,6 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
 
         private Registration columnDataGeneratorRegistration;
 
-        private Renderer<T> renderer;
-
         /**
          * Constructs a new Column for use inside a Grid.
          *
@@ -254,13 +252,11 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
          * @param columnId
          *            unique identifier of this column
          * @param renderer
-         *            the renderer to use in this column, must not be {@code null}
+         *            the renderer to use in this column
          */
         public Column(Grid<T> grid, String columnId, Renderer<T> renderer) {
             super(grid);
-            Objects.requireNonNull(renderer);
             this.columnInternalId = columnId;
-            this.renderer = renderer;
 
             comparator = (a, b) -> 0;
 
@@ -287,19 +283,6 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
 
         protected String getInternalId() {
             return columnInternalId;
-        }
-
-        /**
-         * Get the renderer used for this column.
-         *
-         * Note: Mutating the renderer after the Grid has been rendered
-         * on the client will not change the column, and can lead to
-         * undefined behavior.
-         *
-         * @return the renderer used for this column, should never be {@code null}
-         */
-        public Renderer<T> getRenderer() {
-            return renderer;
         }
 
         /**

--- a/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -916,11 +916,19 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
         String columnId = createColumnId(false);
 
         Column<T> column = addColumn(TemplateRenderer
-                .<T> of("[[item." + columnId + "]]").withProperty(columnId,
-                        value -> String.valueOf(valueProvider.apply(value))));
+                .<T> of("[[item." + columnId + "]]")
+                .withProperty(columnId, value -> formatValueToSendToTheClient(
+                        valueProvider.apply(value))));
         column.comparator = ((a, b) -> compareMaybeComparables(
                 valueProvider.apply(a), valueProvider.apply(b)));
         return column;
+    }
+
+    private String formatValueToSendToTheClient(Object value) {
+        if (value == null) {
+            return "";
+        }
+        return String.valueOf(value);
     }
 
     /**
@@ -1101,8 +1109,9 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
     }
 
     private Column<T> addColumn(PropertyDefinition<T, ?> property) {
-        Column<T> column = addColumn(item -> formatPropertyValue(property, item))
-                .setHeader(property.getCaption());
+        Column<T> column = addColumn(
+                item -> runPropertyValueGetter(property, item))
+                        .setHeader(property.getCaption());
         try {
             return column.setKey(property.getName());
         } catch (IllegalArgumentException exception) {
@@ -1112,13 +1121,9 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
         }
     }
 
-    private Object formatPropertyValue(PropertyDefinition<T, ?> property, T item) {
-        Object value = property.getGetter().apply(item);
-        if(value == null) {
-            return "";
-        } else {
-            return String.valueOf(value);
-        }
+    private Object runPropertyValueGetter(PropertyDefinition<T, ?> property,
+            T item) {
+        return property.getGetter().apply(item);
     }
 
     /**

--- a/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -244,6 +244,8 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
 
         private Registration columnDataGeneratorRegistration;
 
+        private Renderer<T> renderer;
+
         /**
          * Constructs a new Column for use inside a Grid.
          *
@@ -252,11 +254,13 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
          * @param columnId
          *            unique identifier of this column
          * @param renderer
-         *            the renderer to use in this column
+         *            the renderer to use in this column, must not be {@code null}
          */
         public Column(Grid<T> grid, String columnId, Renderer<T> renderer) {
             super(grid);
+            Objects.requireNonNull(renderer);
             this.columnInternalId = columnId;
+            this.renderer = renderer;
 
             comparator = (a, b) -> 0;
 
@@ -283,6 +287,19 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
 
         protected String getInternalId() {
             return columnInternalId;
+        }
+
+        /**
+         * Get the renderer used for this column.
+         *
+         * Note: Mutating the renderer after the Grid has been rendered
+         * on the client will not change the column, and can lead to
+         * undefined behavior.
+         *
+         * @return the renderer used for this column, should never be {@code null}
+         */
+        public Renderer<T> getRenderer() {
+            return renderer;
         }
 
         /**

--- a/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -133,7 +133,7 @@ window.Vaadin.Flow.gridConnector = {
       }
     }
 
-    const sorterChangeListener = function() {
+    const sorterChangeListener = function(event) {
       grid.$server.sortersChanged(grid._sorters.map(function(sorter) {
         return {
           path: sorter.path,
@@ -141,7 +141,7 @@ window.Vaadin.Flow.gridConnector = {
         };
       }));
     }
-    grid._createPropertyObserver("_previousSorters", sorterChangeListener);
+    grid.addEventListener('sorter-changed', sorterChangeListener);
 
     const itemsUpdated = function(items) {
       if (!items || !Array.isArray(items)) {

--- a/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -133,7 +133,7 @@ window.Vaadin.Flow.gridConnector = {
       }
     }
 
-    const sorterChangeListener = function(event) {
+    const sorterChangeListener = function() {
       grid.$server.sortersChanged(grid._sorters.map(function(sorter) {
         return {
           path: sorter.path,
@@ -141,7 +141,7 @@ window.Vaadin.Flow.gridConnector = {
         };
       }));
     }
-    grid.addEventListener('sorter-changed', sorterChangeListener);
+    grid._createPropertyObserver("_previousSorters", sorterChangeListener);
 
     const itemsUpdated = function(items) {
       if (!items || !Array.isArray(items)) {

--- a/src/test/java/com/vaadin/flow/component/grid/BeanGridSortingTest.java
+++ b/src/test/java/com/vaadin/flow/component/grid/BeanGridSortingTest.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import elemental.json.Json;
+import elemental.json.JsonArray;
+import elemental.json.JsonObject;
+
+public class BeanGridSortingTest {
+
+    public static class SortableBean {
+        private String string;
+        private int integer;
+        private boolean bool;
+        private double number;
+
+        private SortableBean innerBean;
+
+        public SortableBean(String string, int integer, boolean bool,
+                double number, SortableBean innerBean) {
+            this.string = string;
+            this.integer = integer;
+            this.bool = bool;
+            this.number = number;
+            this.innerBean = innerBean;
+        }
+
+        public String getString() {
+            return string;
+        }
+
+        public void setString(String string) {
+            this.string = string;
+        }
+
+        public int getInteger() {
+            return integer;
+        }
+
+        public void setInteger(int integer) {
+            this.integer = integer;
+        }
+
+        public boolean isBool() {
+            return bool;
+        }
+
+        public void setBool(boolean bool) {
+            this.bool = bool;
+        }
+
+        public double getNumber() {
+            return number;
+        }
+
+        public void setNumber(double number) {
+            this.number = number;
+        }
+
+        public SortableBean getInnerBean() {
+            return innerBean;
+        }
+
+        public void setInnerBean(SortableBean innerBean) {
+            this.innerBean = innerBean;
+        }
+    }
+
+    private Grid<SortableBean> grid;
+
+    @Before
+    public void init() {
+        grid = new Grid<>(SortableBean.class);
+        grid.setItems(createBeans());
+    }
+
+    @Test
+    public void basicPropertiesAreSortedAsComparables() {
+        grid.setColumns("string", "integer", "bool", "number");
+        grid.getColumnByKey("string").setSortable(true);
+        grid.getColumnByKey("integer").setSortable(true);
+        grid.getColumnByKey("bool").setSortable(true);
+        grid.getColumnByKey("number").setSortable(true);
+
+        callSortersChanged("string", "asc");
+        assertInMemorySorting(
+                (b1, b2) -> b1.getString().compareTo(b2.getString()));
+        callSortersChanged("string", "desc");
+        assertInMemorySorting(
+                (b1, b2) -> b2.getString().compareTo(b1.getString()));
+
+        callSortersChanged("integer", "asc");
+        assertInMemorySorting(
+                (b1, b2) -> Integer.compare(b1.getInteger(), b2.getInteger()));
+        callSortersChanged("integer", "desc");
+        assertInMemorySorting(
+                (b1, b2) -> Integer.compare(b2.getInteger(), b1.getInteger()));
+
+        callSortersChanged("bool", "asc");
+        assertInMemorySorting(
+                (b1, b2) -> Boolean.compare(b1.isBool(), b2.isBool()));
+        callSortersChanged("bool", "desc");
+        assertInMemorySorting(
+                (b1, b2) -> Boolean.compare(b2.isBool(), b1.isBool()));
+
+        callSortersChanged("number", "asc");
+        assertInMemorySorting(
+                (b1, b2) -> Double.compare(b1.getNumber(), b2.getNumber()));
+        callSortersChanged("number", "desc");
+        assertInMemorySorting(
+                (b1, b2) -> Double.compare(b2.getNumber(), b1.getNumber()));
+    }
+
+    @Test
+    public void innerPropertiesAreSortedAsComparables() {
+        grid.setColumns("innerBean.string", "innerBean.integer",
+                "innerBean.bool", "innerBean.number");
+        grid.getColumnByKey("innerBean.string").setSortable(true);
+        grid.getColumnByKey("innerBean.integer").setSortable(true);
+        grid.getColumnByKey("innerBean.bool").setSortable(true);
+        grid.getColumnByKey("innerBean.number").setSortable(true);
+
+        callSortersChanged("innerBean.string", "asc");
+        assertInMemorySorting((b1, b2) -> b1.getInnerBean().getString()
+                .compareTo(b2.getInnerBean().getString()));
+        callSortersChanged("innerBean.string", "desc");
+        assertInMemorySorting((b1, b2) -> b2.getInnerBean().getString()
+                .compareTo(b1.getInnerBean().getString()));
+
+        callSortersChanged("innerBean.integer", "asc");
+        assertInMemorySorting(
+                (b1, b2) -> Integer.compare(b1.getInnerBean().getInteger(),
+                        b2.getInnerBean().getInteger()));
+        callSortersChanged("innerBean.integer", "desc");
+        assertInMemorySorting(
+                (b1, b2) -> Integer.compare(b2.getInnerBean().getInteger(),
+                        b1.getInnerBean().getInteger()));
+
+        callSortersChanged("innerBean.bool", "asc");
+        assertInMemorySorting((b1, b2) -> Boolean.compare(
+                b1.getInnerBean().isBool(), b2.getInnerBean().isBool()));
+        callSortersChanged("innerBean.bool", "desc");
+        assertInMemorySorting((b1, b2) -> Boolean.compare(
+                b2.getInnerBean().isBool(), b1.getInnerBean().isBool()));
+
+        callSortersChanged("innerBean.number", "asc");
+        assertInMemorySorting((b1, b2) -> Double.compare(
+                b1.getInnerBean().getNumber(), b2.getInnerBean().getNumber()));
+        callSortersChanged("innerBean.number", "desc");
+        assertInMemorySorting((b1, b2) -> Double.compare(
+                b2.getInnerBean().getNumber(), b1.getInnerBean().getNumber()));
+    }
+
+    private List<SortableBean> createBeans() {
+        return Arrays.asList(
+                new SortableBean("Bean A", 9, false, 9.5,
+                        new SortableBean("Sub A", 111, true, 111.5, null)),
+                new SortableBean("Bean B", 111, true, 111.5,
+                        new SortableBean("Sub B", 1, false, 1.5, null)),
+                new SortableBean("Bean C", 1, false, 1.5,
+                        new SortableBean("Sub C", 9, false, 9.5, null)));
+    }
+
+    private void assertInMemorySorting(Comparator<SortableBean> comparator) {
+        List<SortableBean> expectedOrder = createBeans();
+        List<SortableBean> actualOrder = new ArrayList<>(expectedOrder);
+
+        expectedOrder.sort(comparator);
+        actualOrder.sort(grid.getDataCommunicator().getInMemorySorting());
+
+        Assert.assertEquals(expectedOrder, actualOrder);
+    }
+
+    private void callSortersChanged(String columnId, String direction) {
+        try {
+            JsonObject json = Json.createObject();
+            json.put("path", grid.getColumnByKey(columnId).getInternalId());
+            json.put("direction", direction);
+
+            JsonArray array = Json.createArray();
+            array.set(0, json);
+
+            Method method = Grid.class.getDeclaredMethod("sortersChanged",
+                    JsonArray.class);
+            method.setAccessible(true);
+            method.invoke(grid, array);
+        } catch (NoSuchMethodException | SecurityException
+                | IllegalAccessException | IllegalArgumentException
+                | InvocationTargetException e) {
+            Assert.fail("Could not call Grid.sortersChanged: " + e);
+        }
+    }
+
+}

--- a/src/test/java/com/vaadin/flow/component/grid/BeanGridSortingTest.java
+++ b/src/test/java/com/vaadin/flow/component/grid/BeanGridSortingTest.java
@@ -37,16 +37,18 @@ public class BeanGridSortingTest {
         private int integer;
         private boolean bool;
         private double number;
+        private Object notComparable;
 
         private SortableBean innerBean;
 
         public SortableBean(String string, int integer, boolean bool,
-                double number, SortableBean innerBean) {
+                double number, SortableBean innerBean, Object notComparable) {
             this.string = string;
             this.integer = integer;
             this.bool = bool;
             this.number = number;
             this.innerBean = innerBean;
+            this.notComparable = notComparable;
         }
 
         public String getString() {
@@ -88,6 +90,14 @@ public class BeanGridSortingTest {
         public void setInnerBean(SortableBean innerBean) {
             this.innerBean = innerBean;
         }
+
+        public void setNotComparable(Object notComparable) {
+            this.notComparable = notComparable;
+        }
+
+        public Object getNotComparable() {
+            return notComparable;
+        }
     }
 
     private Grid<SortableBean> grid;
@@ -101,10 +111,6 @@ public class BeanGridSortingTest {
     @Test
     public void basicPropertiesAreSortedAsComparables() {
         grid.setColumns("string", "integer", "bool", "number");
-        grid.getColumnByKey("string").setSortable(true);
-        grid.getColumnByKey("integer").setSortable(true);
-        grid.getColumnByKey("bool").setSortable(true);
-        grid.getColumnByKey("number").setSortable(true);
 
         callSortersChanged("string", "asc");
         assertInMemorySorting(
@@ -139,10 +145,6 @@ public class BeanGridSortingTest {
     public void innerPropertiesAreSortedAsComparables() {
         grid.setColumns("innerBean.string", "innerBean.integer",
                 "innerBean.bool", "innerBean.number");
-        grid.getColumnByKey("innerBean.string").setSortable(true);
-        grid.getColumnByKey("innerBean.integer").setSortable(true);
-        grid.getColumnByKey("innerBean.bool").setSortable(true);
-        grid.getColumnByKey("innerBean.number").setSortable(true);
 
         callSortersChanged("innerBean.string", "asc");
         assertInMemorySorting((b1, b2) -> b1.getInnerBean().getString()
@@ -174,15 +176,43 @@ public class BeanGridSortingTest {
         assertInMemorySorting((b1, b2) -> Double.compare(
                 b2.getInnerBean().getNumber(), b1.getInnerBean().getNumber()));
     }
+    
+    @Test
+    public void setSortableColumns_onlyComparablePropertiesAreSortable() {
+        Assert.assertTrue(grid.getColumnByKey("string").isSortable());
+        Assert.assertFalse(grid.getColumnByKey("notComparable").isSortable());
+
+        grid.setColumns("string", "notComparable", "innerBean",
+                "innerBean.string");
+
+        Assert.assertTrue(grid.getColumnByKey("string").isSortable());
+        Assert.assertFalse(grid.getColumnByKey("notComparable").isSortable());
+        Assert.assertFalse(grid.getColumnByKey("innerBean").isSortable());
+        Assert.assertTrue(grid.getColumnByKey("innerBean.string").isSortable());
+
+        grid.addColumn("bool");
+        grid.addColumn("innerBean.notComparable");
+
+        Assert.assertTrue(grid.getColumnByKey("bool").isSortable());
+        Assert.assertFalse(
+                grid.getColumnByKey("innerBean.notComparable").isSortable());
+
+    }
 
     private List<SortableBean> createBeans() {
         return Arrays.asList(
                 new SortableBean("Bean A", 9, false, 9.5,
-                        new SortableBean("Sub A", 111, true, 111.5, null)),
+                        new SortableBean("Sub A", 111, true, 111.5, null,
+                                "Not comparable A"),
+                        "Not comparable 1"),
                 new SortableBean("Bean B", 111, true, 111.5,
-                        new SortableBean("Sub B", 1, false, 1.5, null)),
-                new SortableBean("Bean C", 1, false, 1.5,
-                        new SortableBean("Sub C", 9, false, 9.5, null)));
+                        new SortableBean("Sub B", 1, false, 1.5, null,
+                                "Not comparable B"),
+                        "Not comparable 2"),
+                new SortableBean(
+                        "Bean C", 1, false, 1.5, new SortableBean("Sub C", 9,
+                                false, 9.5, null, "Not comparable C"),
+                        "Not comparable 3"));
     }
 
     private void assertInMemorySorting(Comparator<SortableBean> comparator) {

--- a/src/test/java/com/vaadin/flow/component/grid/GridColumnTest.java
+++ b/src/test/java/com/vaadin/flow/component/grid/GridColumnTest.java
@@ -21,9 +21,13 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.grid.Grid.Column;
+import com.vaadin.flow.component.html.Label;
 import com.vaadin.flow.data.provider.SortDirection;
+import com.vaadin.flow.data.renderer.IconRenderer;
 import com.vaadin.flow.function.SerializableComparator;
+import com.vaadin.flow.function.SerializableFunction;
 
 public class GridColumnTest {
 
@@ -31,6 +35,9 @@ public class GridColumnTest {
     Column<String> firstColumn;
     Column<String> secondColumn;
     Column<String> thirdColumn;
+    Column<String> fourthColumn;
+
+    IconRenderer<String> renderer;
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
@@ -41,6 +48,8 @@ public class GridColumnTest {
         firstColumn = grid.addColumn(str -> str);
         secondColumn = grid.addColumn(str -> str);
         thirdColumn = grid.addColumn(str -> str);
+        renderer = new IconRenderer<String>(generator -> new Label(":D"));
+        fourthColumn = grid.addColumn(renderer);
     }
 
     @Test
@@ -164,6 +173,11 @@ public class GridColumnTest {
                 -1, result);
     }
 
+    @Test
+    public void testRenderer() {
+        assert renderer!= null;
+        Assert.assertEquals(renderer, fourthColumn.getRenderer());
+    }
     private void expectNullPointerException(String message) {
         thrown.expect(NullPointerException.class);
         thrown.expectMessage(message);

--- a/src/test/java/com/vaadin/flow/component/grid/GridColumnTest.java
+++ b/src/test/java/com/vaadin/flow/component/grid/GridColumnTest.java
@@ -21,13 +21,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.grid.Grid.Column;
-import com.vaadin.flow.component.html.Label;
 import com.vaadin.flow.data.provider.SortDirection;
-import com.vaadin.flow.data.renderer.IconRenderer;
 import com.vaadin.flow.function.SerializableComparator;
-import com.vaadin.flow.function.SerializableFunction;
 
 public class GridColumnTest {
 
@@ -35,9 +31,6 @@ public class GridColumnTest {
     Column<String> firstColumn;
     Column<String> secondColumn;
     Column<String> thirdColumn;
-    Column<String> fourthColumn;
-
-    IconRenderer<String> renderer;
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
@@ -48,8 +41,6 @@ public class GridColumnTest {
         firstColumn = grid.addColumn(str -> str);
         secondColumn = grid.addColumn(str -> str);
         thirdColumn = grid.addColumn(str -> str);
-        renderer = new IconRenderer<String>(generator -> new Label(":D"));
-        fourthColumn = grid.addColumn(renderer);
     }
 
     @Test
@@ -173,11 +164,6 @@ public class GridColumnTest {
                 -1, result);
     }
 
-    @Test
-    public void testRenderer() {
-        assert renderer!= null;
-        Assert.assertEquals(renderer, fourthColumn.getRenderer());
-    }
     private void expectNullPointerException(String message) {
         thrown.expect(NullPointerException.class);
         thrown.expectMessage(message);

--- a/src/test/java/com/vaadin/flow/component/grid/it/BeanGridSortingIT.java
+++ b/src/test/java/com/vaadin/flow/component/grid/it/BeanGridSortingIT.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.it;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.flow.component.grid.testbench.GridElement;
+import com.vaadin.flow.testutil.AbstractComponentIT;
+import com.vaadin.flow.testutil.TestPath;
+
+@TestPath("bean-grid-sorting")
+public class BeanGridSortingIT extends AbstractComponentIT {
+
+    @Test
+    public void sortBornColumn_valuesAreSortedAsIntegers() {
+        open();
+        GridElement grid = $(GridElement.class).first();
+
+        // Original values
+        Assert.assertEquals("99", grid.getCell(0, 1).getText());
+        Assert.assertEquals("1111", grid.getCell(1, 1).getText());
+        Assert.assertEquals("1", grid.getCell(2, 1).getText());
+
+        // Sort by ascending order
+        grid.getHeaderCell(1).$("vaadin-grid-sorter").first().click();
+
+        Assert.assertEquals("1", grid.getCell(0, 1).getText());
+        Assert.assertEquals("99", grid.getCell(1, 1).getText());
+        Assert.assertEquals("1111", grid.getCell(2, 1).getText());
+
+        // Sort by descending order
+        grid.getHeaderCell(1).$("vaadin-grid-sorter").first().click();
+
+        Assert.assertEquals("1111", grid.getCell(0, 1).getText());
+        Assert.assertEquals("99", grid.getCell(1, 1).getText());
+        Assert.assertEquals("1", grid.getCell(2, 1).getText());
+    }
+
+}

--- a/src/test/java/com/vaadin/flow/component/grid/it/BeanGridSortingPage.java
+++ b/src/test/java/com/vaadin/flow/component/grid/it/BeanGridSortingPage.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.it;
+
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.grid.Person;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.theme.NoTheme;
+
+@Route("bean-grid-sorting")
+@NoTheme
+public class BeanGridSortingPage extends Div {
+
+    public BeanGridSortingPage() {
+        Grid<Person> grid = new Grid<>(Person.class);
+        grid.setItems(new Person("Person 1", 99), new Person("Person 2", 1111),
+                new Person("Person 3", 1));
+        grid.setColumns("name", "born");
+        grid.getColumnByKey("born").setSortable(true);
+        add(grid);
+    }
+
+}

--- a/src/test/java/com/vaadin/flow/component/grid/it/BeanGridSortingPage.java
+++ b/src/test/java/com/vaadin/flow/component/grid/it/BeanGridSortingPage.java
@@ -30,7 +30,6 @@ public class BeanGridSortingPage extends Div {
         grid.setItems(new Person("Person 1", 99), new Person("Person 2", 1111),
                 new Person("Person 3", 1));
         grid.setColumns("name", "born");
-        grid.getColumnByKey("born").setSortable(true);
         add(grid);
     }
 

--- a/src/test/java/com/vaadin/flow/component/grid/it/ButtonInGridIT.java
+++ b/src/test/java/com/vaadin/flow/component/grid/it/ButtonInGridIT.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.component.grid.it;
 
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
@@ -30,15 +29,6 @@ import com.vaadin.flow.testutil.TestPath;
 public class ButtonInGridIT extends AbstractComponentIT {
 
     @Test
-    @Ignore
-    /**
-     * The test is disabled due #4268. The test is for grid#122 (which is
-     * actually an issue in the flow-component-renderer inside flow-data
-     * module).
-     *
-     * At the moment the bug is not fixed. So the test fails. Should be enabled
-     * back once the gird#122 is fixed.
-     */
     public void pressButtonUsingKeyboard() {
         open();
 

--- a/src/test/java/com/vaadin/flow/component/grid/it/ButtonInGridIT.java
+++ b/src/test/java/com/vaadin/flow/component/grid/it/ButtonInGridIT.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.component.grid.it;
 
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
@@ -29,6 +30,15 @@ import com.vaadin.flow.testutil.TestPath;
 public class ButtonInGridIT extends AbstractComponentIT {
 
     @Test
+    @Ignore
+    /**
+     * The test is disabled due #4268. The test is for grid#122 (which is
+     * actually an issue in the flow-component-renderer inside flow-data
+     * module).
+     *
+     * At the moment the bug is not fixed. So the test fails. Should be enabled
+     * back once the gird#122 is fixed.
+     */
     public void pressButtonUsingKeyboard() {
         open();
 

--- a/src/test/java/com/vaadin/flow/component/grid/it/GridViewIT.java
+++ b/src/test/java/com/vaadin/flow/component/grid/it/GridViewIT.java
@@ -811,7 +811,7 @@ public class GridViewIT extends TabbedComponentDemoTest {
                     .filter(el -> el.getAttribute("id")
                             .equals("person-card-" + (rowIndex + 1)))
                     .findAny().isPresent();
-        });
+        }, 20);
         WebElement element = grid.findElements(By.className("custom-details"))
                 .stream()
                 .filter(el -> el.getAttribute("id")

--- a/src/test/java/com/vaadin/flow/component/grid/it/GridWithTemplateIT.java
+++ b/src/test/java/com/vaadin/flow/component/grid/it/GridWithTemplateIT.java
@@ -19,7 +19,6 @@ import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
@@ -88,10 +87,8 @@ public class GridWithTemplateIT extends AbstractComponentIT {
     }
 
     @Test
-    @Ignore
     /*
-     * Ignored due to the issue
-     * https://github.com/vaadin/vaadin-grid-flow/issues/71
+     * Test for the issue https://github.com/vaadin/vaadin-grid-flow/issues/71
      */
     public void injectedGrid_detailsWithTemplates_buttonIsClicked_detailIsUpdated() {
         WebElement gridInATemplate = findElement(

--- a/src/test/java/com/vaadin/flow/component/grid/it/RefreshAndMakeVisibleGridIT.java
+++ b/src/test/java/com/vaadin/flow/component/grid/it/RefreshAndMakeVisibleGridIT.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.it;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import com.vaadin.flow.testutil.AbstractComponentIT;
+import com.vaadin.flow.testutil.TestPath;
+
+@TestPath("refresh-invisible-grid")
+public class RefreshAndMakeVisibleGridIT extends AbstractComponentIT {
+
+    @Test
+    public void refreshDataProviderAndMakeGridVisible() {
+        open();
+
+        findElement(By.id("refresh")).click();
+        checkLogsForErrors();
+
+        boolean hasFooCell = $("vaadin-grid-cell-content").all().stream()
+                .anyMatch(element -> "foo".equals(element.getText()));
+
+        Assert.assertTrue(
+                "Grid has no 'foo' cell after making it visible and refresh data provider",
+                hasFooCell);
+    }
+}

--- a/src/test/java/com/vaadin/flow/component/grid/it/RefreshAndMakeVisibleGridPage.java
+++ b/src/test/java/com/vaadin/flow/component/grid/it/RefreshAndMakeVisibleGridPage.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.it;
+
+import java.util.ArrayList;
+
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.data.provider.ListDataProvider;
+import com.vaadin.flow.function.ValueProvider;
+import com.vaadin.flow.router.Route;
+
+@Route("refresh-invisible-grid")
+public class RefreshAndMakeVisibleGridPage extends Div {
+
+    private Grid<String> grid;
+    private ListDataProvider<String> dataProvider;
+
+    public RefreshAndMakeVisibleGridPage() {
+        grid = new Grid<>();
+        dataProvider = new ListDataProvider<>(new ArrayList<>());
+        grid.setDataProvider(dataProvider);
+        grid.setVisible(false);
+        grid.addColumn(ValueProvider.identity()).setHeader("Name");
+
+        NativeButton button = new NativeButton("Make grid visible", event -> {
+            dataProvider.getItems().clear();
+            dataProvider.getItems().add("foo");
+            dataProvider.refreshAll();
+            grid.setVisible(true);
+        });
+
+        button.setId("refresh");
+
+        add(grid, button);
+    }
+
+}

--- a/src/test/java/com/vaadin/flow/component/grid/it/SelectAndMakeVisibleIT.java
+++ b/src/test/java/com/vaadin/flow/component/grid/it/SelectAndMakeVisibleIT.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.it;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import com.vaadin.flow.testutil.AbstractComponentIT;
+import com.vaadin.flow.testutil.TestPath;
+
+@TestPath("select-invisible-grid")
+public class SelectAndMakeVisibleIT extends AbstractComponentIT {
+
+    @Test
+    public void selectRowAndMakeGridVisible() throws InterruptedException {
+        open();
+
+        findElement(By.id("select")).click();
+        checkLogsForErrors();
+
+        Long selectedLength = (Long) getCommandExecutor().executeScript(
+                "return arguments[0].selectedItems.length;",
+                findElement(By.tagName("vaadin-grid")));
+        Assert.assertEquals("Unexpected number of selected items", 1l,
+                selectedLength.longValue());
+    }
+}

--- a/src/test/java/com/vaadin/flow/component/grid/it/SelectAndMakeVisiblePage.java
+++ b/src/test/java/com/vaadin/flow/component/grid/it/SelectAndMakeVisiblePage.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.it;
+
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.function.ValueProvider;
+import com.vaadin.flow.router.Route;
+
+@Route("select-invisible-grid")
+public class SelectAndMakeVisiblePage extends Div {
+
+    public SelectAndMakeVisiblePage() {
+        Grid<String> grid = new Grid<>();
+        grid.setItems("foo", "bar");
+        grid.setVisible(false);
+        grid.addColumn(ValueProvider.identity()).setHeader("Name");
+
+        NativeButton button = new NativeButton("Make grid visible", event -> {
+            grid.setVisible(true);
+            grid.getSelectionModel().select("foo");
+        });
+
+        button.setId("select");
+
+        add(grid, button);
+    }
+}

--- a/src/test/java/com/vaadin/flow/component/grid/it/ToggleVisibilityIT.java
+++ b/src/test/java/com/vaadin/flow/component/grid/it/ToggleVisibilityIT.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.it;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.flow.component.grid.testbench.GridElement;
+import com.vaadin.flow.testutil.AbstractComponentIT;
+import com.vaadin.flow.testutil.TestPath;
+
+@TestPath("toggle-visibility")
+public class ToggleVisibilityIT extends AbstractComponentIT {
+
+    @Test
+    public void toggleVisibility_secondGridIsVisible() {
+        open();
+
+        waitForElementPresent(By.id("toggle-visibility-grid1"));
+        checkLogsForErrors();
+
+        GridElement grid1 = $(GridElement.class).id("toggle-visibility-grid1");
+        Assert.assertEquals("Grid1 Item 0", grid1.getCell(0, 0).getText());
+
+        WebElement toggle = findElement(By.id("toggle-visibility-button"));
+        toggle.click();
+
+        waitForElementPresent(By.id("toggle-visibility-grid2"));
+        checkLogsForErrors();
+
+        GridElement grid2 = $(GridElement.class).id("toggle-visibility-grid2");
+        Assert.assertEquals("Grid2 Item 0", grid2.getCell(0, 0).getText());
+
+        toggle.click();
+        waitForElementPresent(By.id("toggle-visibility-grid1"));
+        checkLogsForErrors();
+    }
+
+}

--- a/src/test/java/com/vaadin/flow/component/grid/it/ToggleVisibilityPage.java
+++ b/src/test/java/com/vaadin/flow/component/grid/it/ToggleVisibilityPage.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.it;
+
+import java.util.stream.IntStream;
+
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.function.ValueProvider;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.theme.NoTheme;
+
+/**
+ * Page that reproduces the bug described at
+ * https://github.com/vaadin/flow/issues/4448
+ * 
+ * @author Vaadin Ltd.
+ */
+@Route("toggle-visibility")
+@NoTheme
+public class ToggleVisibilityPage extends Div {
+
+    public ToggleVisibilityPage() {
+        Grid<String> grid1 = new Grid<>();
+        grid1.setItems(
+                IntStream.range(0, 100).mapToObj(i -> "Grid1 Item " + i));
+        grid1.addColumn(ValueProvider.identity());
+
+        Grid<String> grid2 = new Grid<>();
+        grid2.setItems(
+                IntStream.range(0, 100).mapToObj(i -> "Grid2 Item " + i));
+        grid2.addColumn(ValueProvider.identity());
+
+        Div parent1 = new Div(grid1);
+        Div parent2 = new Div(grid2);
+
+        parent2.setVisible(false);
+
+        NativeButton toggleVisibility = new NativeButton("Toggle visibility",
+                event -> {
+                    parent1.setVisible(!parent1.isVisible());
+                    parent2.setVisible(!parent2.isVisible());
+                });
+
+        grid1.setId("toggle-visibility-grid1");
+        grid2.setId("toggle-visibility-grid2");
+        toggleVisibility.setId("toggle-visibility-button");
+
+        add(parent1, parent2, toggleVisibility);
+    }
+
+}


### PR DESCRIPTION
* Observe changes in _previousSorters instead of using an eventListener.

This way we update the serverside sorting always after the
sorter-changed event has been handled by grid.

Cherry pick from master

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-flow/303)
<!-- Reviewable:end -->
