### PR TITLE
getRenderer Javadoc formatting

### DIFF
--- a/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -318,8 +318,8 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
 
         /**
          * Get the renderer used for this column.
-         *
-         * Note: Mutating the renderer after the Grid has been rendered on the
+         * <p>
+         * <strong>Note:</strong> Mutating the renderer after the Grid has been rendered on the
          * client will not change the column, and can lead to undefined
          * behavior.
          *


### PR DESCRIPTION
added formatting to getRenderer Javadoc

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-flow/312)
<!-- Reviewable:end -->
