### PR TITLE
Fix details generator clearing when reusing details component.

### DIFF
--- a/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -922,9 +922,8 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
             }
 
             if (itemDetailsDataGenerator != null && refresh) {
-                if (detailsVisible.contains(item)) {
-                    refresh(item);
-                } else {
+                refresh(item);
+                if (!detailsVisible.contains(item)) {
                     itemDetailsDataGenerator.destroyData(item);
                 }
             }

--- a/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -922,8 +922,11 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
             }
 
             if (itemDetailsDataGenerator != null && refresh) {
-                refresh(item);
-                itemDetailsDataGenerator.destroyData(item);
+                if (detailsVisible.contains(item)) {
+                    refresh(item);
+                } else {
+                    itemDetailsDataGenerator.destroyData(item);
+                }
             }
         }
 

--- a/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -923,6 +923,7 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
 
             if (itemDetailsDataGenerator != null && refresh) {
                 refresh(item);
+                itemDetailsDataGenerator.destroyData(item);
             }
         }
 
@@ -966,8 +967,12 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
 
         @Override
         public void refreshData(T item) {
-            if (itemDetailsDataGenerator != null && isDetailsVisible(item)) {
-                itemDetailsDataGenerator.refreshData(item);
+            if (itemDetailsDataGenerator != null) {
+                if (isDetailsVisible(item)) {
+                    itemDetailsDataGenerator.refreshData(item);
+                } else {
+                    itemDetailsDataGenerator.destroyData(item);
+                }
             }
         }
 

--- a/src/test/java/com/vaadin/flow/component/grid/it/DetailsGridIT.java
+++ b/src/test/java/com/vaadin/flow/component/grid/it/DetailsGridIT.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.it;
+
+import java.util.List;
+import java.util.Locale;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.flow.component.grid.testbench.GridElement;
+import com.vaadin.flow.testutil.AbstractComponentIT;
+import com.vaadin.flow.testutil.TestPath;
+
+@TestPath("detailsGrid")
+public class DetailsGridIT extends AbstractComponentIT {
+
+    @Test
+    public void openingMultipleDetails_navigatingAwayDoesntThrow() {
+        open();
+
+        GridElement grid = $(GridElement.class).first();
+
+        assertAmountOfOpenDetails(grid, 0);
+
+        clickElementWithJs(getRow(grid, 0).findElement(By.tagName("td")));
+
+        WebElement detailsElement = grid
+                .findElement(By.tagName("flow-component-renderer"));
+
+        List<WebElement> children = detailsElement
+                .findElements(By.tagName("span"));
+        Assert.assertEquals(1, children.size());
+
+        Assert.assertEquals("span",
+                children.get(0).getTagName().toLowerCase(Locale.ENGLISH));
+        Assert.assertEquals("Jorma", children.get(0).getText());
+
+        clickElementWithJs(getRow(grid, 1).findElement(By.tagName("td")));
+
+        Assert.assertEquals("Expected element to be reused in new details view",
+                "Jarmo", children.get(0).getText());
+
+        clickElementWithJs(getRow(grid, 2).findElement(By.tagName("td")));
+
+        Assert.assertEquals("Expected element to be reused in new details view",
+                "Jethro", children.get(0).getText());
+
+
+        findElement(By.id("next")).click();
+
+        Assert.assertEquals(
+                "Expected to find one grid on new page. Encountered something unexpected.",
+                1, findElements(By.id("grid")).size());
+    }
+
+    private void assertAmountOfOpenDetails(WebElement grid,
+            int expectedAmount) {
+        waitUntil(driver ->
+                grid.findElements(By.className("custom-details")).size()
+                        == expectedAmount);
+        Assert.assertEquals(expectedAmount,
+                grid.findElements(By.className("custom-details")).size());
+    }
+
+    private WebElement getRow(WebElement grid, int row) {
+        return getInShadowRoot(grid, By.id("items"))
+                .findElements(By.cssSelector("tr")).get(row);
+    }
+}

--- a/src/test/java/com/vaadin/flow/component/grid/it/DetailsGridPage.java
+++ b/src/test/java/com/vaadin/flow/component/grid/it/DetailsGridPage.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.it;
+
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.grid.Person;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.data.renderer.ComponentRenderer;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.RouterLink;
+
+/**
+ * Details grid uses the same component for all shown details.
+ * If the grid itemDetailsDataGenerator is not correctly cleaned then
+ * there will be an exception when navigating and all data is cleared.
+ */
+@Route("detailsGrid")
+public class DetailsGridPage extends Div {
+
+    Span text = new Span("wow");
+
+    public DetailsGridPage() {
+        Grid<Person> grid = new Grid<>(Person.class);
+
+        grid.setItems(new Person("Jorma", 2018), new Person("Jarmo", 2018),
+                new Person("Jethro", 2018));
+
+        grid.setItemDetailsRenderer(new ComponentRenderer<>(person -> {
+            text.setText(person.getName());
+            return text;
+        }));
+
+        RouterLink next = new RouterLink("next", DisabledGridPage.class);
+        next.setId("next");
+        add(grid, next);
+    }
+}

--- a/src/test/java/com/vaadin/flow/component/grid/it/GridWithTemplatePage.java
+++ b/src/test/java/com/vaadin/flow/component/grid/it/GridWithTemplatePage.java
@@ -36,7 +36,7 @@ public class GridWithTemplatePage extends Div {
         createGridInATemplateWithTemplatesInTheHeader();
         createGridInTemplateWithColumnProperties();
 
-        getElement().appendChild(new Element("hr", false));
+        getElement().appendChild(new Element("hr"));
         add(new H2("Standalone Grid"));
         createStandaloneGridWithTemplatesInTheCells();
         createStandaloneGridWithTemplatesInTheDetails();


### PR DESCRIPTION
Remove deprecated `new Element(String, boolean)` usage.

Fixes #376

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-flow/377)
<!-- Reviewable:end -->
