### PR TITLE
Add setVerticalScrollingEnabled method

### DIFF
--- a/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -1056,6 +1056,8 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
 
     private Editor<T> editor;
 
+    private boolean verticalScrollingEnabled = true;
+
     /**
      * Creates a new instance, with page size of 50.
      */
@@ -2787,6 +2789,33 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
             ComponentEventListener<ItemDoubleClickEvent<T>> listener) {
         return addListener(ItemDoubleClickEvent.class,
                 (ComponentEventListener) Objects.requireNonNull(listener));
+    }
+
+    /**
+     * Enables or disables the vertical scrolling on the Grid web component. By
+     * default, the scrolling is enabled.
+     * 
+     * @param enabled
+     *            <code>true</code> to enable vertical scrolling,
+     *            <code>false</code> to disabled it
+     */
+    public void setVerticalScrollingEnabled(boolean enabled) {
+        if (isVerticalScrollingEnabled() == enabled) {
+            return;
+        }
+        verticalScrollingEnabled = enabled;
+        getElement().callFunction("$connector.setVerticalScrollingEnabled",
+                enabled);
+    }
+
+    /**
+     * Gets whether the vertical scrolling on the Grid web component is enabled.
+     * 
+     * @return <code>true</code> if the vertical scrolling is enabled,
+     *         <code>false</code> otherwise
+     */
+    public boolean isVerticalScrollingEnabled() {
+        return verticalScrollingEnabled;
     }
 
     /**

--- a/src/test/java/com/vaadin/flow/component/grid/it/EditorVerticalScrollingIT.java
+++ b/src/test/java/com/vaadin/flow/component/grid/it/EditorVerticalScrollingIT.java
@@ -1,0 +1,52 @@
+package com.vaadin.flow.component.grid.it;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import com.vaadin.flow.component.grid.testbench.GridElement;
+import com.vaadin.flow.testutil.AbstractComponentIT;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+
+@TestPath("editor-vertical-scrolling")
+public class EditorVerticalScrollingIT extends AbstractComponentIT {
+
+    private GridElement grid;
+
+    @Before
+    public void init() {
+        open();
+        waitForElementPresent(By.id("editor-grid"));
+        grid = $(GridElement.class).id("editor-grid");
+
+        waitForElementPresent(By.id("edit-1"));
+    }
+
+    @Test
+    public void editRow_scrollingIsDisabled_closeEditor_scrollingIsRestored() {
+        String overflow = grid.findInShadowRoot(By.id("table")).get(0)
+                .getCssValue("overflow-y");
+        Assert.assertEquals("auto", overflow);
+
+        TestBenchElement editButton = grid.findElement(By.id("edit-1"));
+        editButton.click();
+
+        waitForElementPresent(By.id("cancel-1"));
+
+        overflow = grid.findInShadowRoot(By.id("table")).get(0)
+                .getCssValue("overflow-y");
+        Assert.assertEquals("hidden", overflow);
+
+        TestBenchElement cancelButton = grid.findElement(By.id("cancel-1"));
+        cancelButton.click();
+
+        waitForElementPresent(By.id("edit-1"));
+
+        overflow = grid.findInShadowRoot(By.id("table")).get(0)
+                .getCssValue("overflow-y");
+        Assert.assertEquals("auto", overflow);
+    }
+
+}

--- a/src/test/java/com/vaadin/flow/component/grid/it/EditorVerticalScrollingPage.java
+++ b/src/test/java/com/vaadin/flow/component/grid/it/EditorVerticalScrollingPage.java
@@ -1,0 +1,91 @@
+package com.vaadin.flow.component.grid.it;
+
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.grid.Grid.SelectionMode;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.textfield.TextField;
+import com.vaadin.flow.data.bean.Person;
+import com.vaadin.flow.data.binder.Binder;
+import com.vaadin.flow.data.renderer.ComponentRenderer;
+import com.vaadin.flow.router.Route;
+
+@Route("editor-vertical-scrolling")
+public class EditorVerticalScrollingPage extends Div {
+
+    private Grid<Person> grid = new Grid<>();
+
+    public EditorVerticalScrollingPage() {
+        setSizeFull();
+        grid.setSelectionMode(SelectionMode.NONE);
+        grid.setId("editor-grid");
+        grid.setItems(IntStream.range(1, 1001).mapToObj(this::createPerson)
+                .collect(Collectors.toList()));
+        Binder<Person> binder = new Binder<>(Person.class);
+        TextField editorComponent = new TextField();
+        editorComponent.setId("editor");
+        grid.addColumn(Person::getFirstName).setHeader("Name").setEditorBinding(
+                binder.forField(editorComponent).bind("firstName"));
+        grid.addColumn(new ComponentRenderer<>(this::createComponent,
+                this::editComponent));
+        grid.getEditor().setBuffered(true).setBinder(binder);
+
+        grid.getEditor().addOpenListener(
+                event -> grid.setVerticalScrollingEnabled(false));
+        grid.getEditor().addCloseListener(
+                event -> grid.setVerticalScrollingEnabled(true));
+        grid.setSizeFull();
+        add(grid);
+    }
+
+    private Component editComponent(Component oldComponent, Person item) {
+        return oldComponent;
+    }
+
+    private Person createPerson(int index) {
+        Person person = new Person();
+        person.setFirstName("Person " + index);
+        person.setLastName(String.valueOf(index));
+        return person;
+    }
+
+    private Component createComponent(Person item) {
+        NativeButton save = new NativeButton("Save");
+        NativeButton cancel = new NativeButton("Cancel");
+        NativeButton edit = new NativeButton("Edit");
+        save.addClickListener(event -> {
+            if (grid.getEditor().save()) {
+                save.setVisible(false);
+                cancel.setVisible(false);
+                edit.setVisible(true);
+            }
+        });
+        cancel.addClickListener(event -> {
+            grid.getEditor().cancel();
+            save.setVisible(false);
+            cancel.setVisible(false);
+            edit.setVisible(true);
+        });
+        edit.addClickListener(event -> {
+            if (grid.getEditor().isOpen()) {
+                grid.getEditor().cancel();
+            }
+            grid.getEditor().editItem(item);
+            save.setVisible(true);
+            cancel.setVisible(true);
+            edit.setVisible(false);
+        });
+        cancel.setVisible(false);
+        save.setVisible(false);
+        Div container = new Div(edit, save, cancel);
+        edit.setId("edit-" + item.getLastName());
+        save.setId("save-" + item.getLastName());
+        cancel.setId("cancel-" + item.getLastName());
+        return container;
+    }
+
+}


### PR DESCRIPTION
The method enables/disables the vertical scrolling in the Grid. This can
be used in conjunction with the editor, to prevent the scrolling while
an item is being edited.

Related to #357 