### PR TITLE
Fix for https://github.com/vaadin/vaadin-grid-flow/issues/380. 

### DIFF
--- a/src/test/java/com/vaadin/flow/component/grid/demo/GridView.java
+++ b/src/test/java/com/vaadin/flow/component/grid/demo/GridView.java
@@ -989,14 +989,14 @@ public class GridView extends DemoView {
 
         // LocalDateTimeRenderer for date and time
         grid.addColumn(new LocalDateTimeRenderer<>(Item::getPurchaseDate,
-                DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT,
-                        FormatStyle.MEDIUM)))
-                .setHeader("Purchase date and time").setFlexGrow(2);
+            DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT,
+                FormatStyle.MEDIUM).withLocale ( Locale.ENGLISH )))
+            .setHeader("Purchase date and time").setFlexGrow(2);
 
         // LocalDateRenderer for dates
         grid.addColumn(new LocalDateRenderer<>(Item::getEstimatedDeliveryDate,
-                DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM)))
-                .setHeader("Estimated delivery date");
+            DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM).withLocale ( Locale.ENGLISH )))
+            .setHeader("Estimated delivery date");
 
         // Icons
         grid.addColumn(new IconRenderer<>(


### PR DESCRIPTION
DateTimeFormatter instances in (test) GridView now always use english locale as is used for assertion in GridViewIT.