### PR TITLE
Fix tests and connector to properly support grid 5.2.1

### DIFF
--- a/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -346,7 +346,7 @@ window.Vaadin.Flow.gridConnector = {
         }
 
         let parentCache = grid.$connector.getCacheByKey(parentUniqueKey);
-        let itemCache = (parentCache) ? parentCache.itemkeyCaches[parentUniqueKey] : undefined;
+        let itemCache = (parentCache && parentCache.itemkeyCaches) ? parentCache.itemkeyCaches[parentUniqueKey] : undefined;
         if(cache[parentUniqueKey] && cache[parentUniqueKey][page] && itemCache) {
           // workaround: sometimes grid-element gives page index that overflows
           page = Math.min(page, Math.floor(itemCache.size / grid.pageSize));
@@ -420,7 +420,8 @@ window.Vaadin.Flow.gridConnector = {
     }
 
     grid._expandedInstanceChangedCallback = function(inst, value) {
-      if (inst.item == undefined) {
+      // method available only for the TreeGrid server-side component
+      if (inst.item == undefined || grid.$server.updateExpandedState == undefined) {
         return;
       }
       let parentKey = grid.getItemId(inst.item);
@@ -430,7 +431,7 @@ window.Vaadin.Flow.gridConnector = {
       } else {
         delete cache[parentKey];
         let parentCache = grid.$connector.getCacheByKey(parentKey);
-        if(parentCache && parentCache.itemkeyCaches[parentKey]) {
+        if(parentCache && parentCache.itemkeyCaches && parentCache.itemkeyCaches[parentKey]) {
           parentCache.itemkeyCaches[parentKey].items = [];
         }
         delete lastRequestedRanges[parentKey];
@@ -476,7 +477,7 @@ window.Vaadin.Flow.gridConnector = {
       if((parentKey || root) !== root) {
         const items = cache[parentKey][page];
         let parentCache = grid.$connector.getCacheByKey(parentKey);
-        if(parentCache) {
+        if(parentCache && parentCache.itemkeyCaches) {
           let _cache = parentCache.itemkeyCaches[parentKey];
           _updateGridCache(page, items,
             treePageCallbacks[parentKey][page],

--- a/src/test/java/com/vaadin/flow/component/grid/it/GridLoadsItemsIT.java
+++ b/src/test/java/com/vaadin/flow/component/grid/it/GridLoadsItemsIT.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
+import com.vaadin.flow.component.grid.testbench.GridElement;
 import com.vaadin.flow.testutil.AbstractComponentIT;
 import com.vaadin.flow.testutil.TestPath;
 
@@ -45,8 +46,8 @@ public class GridLoadsItemsIT extends AbstractComponentIT {
         List<String> messages = getMessages();
 
         Assert.assertEquals(
-                "There should be two queries, one for eagerly fetched data and one to fill the buffer based on the size of the Grid",
-                Arrays.asList("Fetch 0 - 50", "Fetch 50 - 150"), messages);
+                "There should be just one query, that fills up the pageSize of the Grid",
+                Arrays.asList("Fetch 0 - 50"), messages);
     }
 
     @Test
@@ -55,14 +56,14 @@ public class GridLoadsItemsIT extends AbstractComponentIT {
 
         findElement(By.id("clear-messages")).click();
 
-        WebElement grid = findElement(By.id("data-grid"));
-        executeScript("return arguments[0].scrollToIndex(500)", grid);
+        GridElement grid = $(GridElement.class).id("data-grid");
+        grid.scrollToRow(500);
 
         List<String> messages = getMessages();
 
         Assert.assertEquals(
-                "There should be one query fetching two previous pages, the current page, and two upcoming pages",
-                Arrays.asList("Fetch 400 - 650"), messages);
+                "There should be one query fetching two previous pages (400-450 + 450-500), the current page (500-550), and one upcoming page (550-600)",
+                Arrays.asList("Fetch 400 - 600"), messages);
     }
 
     private List<String> getMessages() {

--- a/src/test/java/com/vaadin/flow/component/grid/testbench/GridElement.java
+++ b/src/test/java/com/vaadin/flow/component/grid/testbench/GridElement.java
@@ -15,15 +15,16 @@
  */
 package com.vaadin.flow.component.grid.testbench;
 
-import com.vaadin.testbench.TestBenchElement;
-import com.vaadin.testbench.elementsbase.Element;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.junit.Assert;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 
-import java.util.List;
-import java.util.stream.Collectors;
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.elementsbase.Element;
 
 /**
  * A TestBench element representing a <code>&lt;vaadin-grid&gt;</code> element.
@@ -175,7 +176,7 @@ public class GridElement extends TestBenchElement {
         String script = "var grid = arguments[0];"
                 + "var rowIndex = arguments[1];"
                 + "var rowsInDom = grid.$.items.children;"
-                + "var rowInDom = Array.from(rowsInDom).filter(function(row) { return row.index == rowIndex;})[0];"
+                + "var rowInDom = Array.from(rowsInDom).filter(function(row) { return !row.hidden && row.index == rowIndex;})[0];"
                 + "return rowInDom;";
         return ((TestBenchElement) executeScript(script, this, rowIndex))
                 .wrap(GridTRElement.class);

--- a/src/test/java/com/vaadin/flow/component/grid/testbench/GridTRElement.java
+++ b/src/test/java/com/vaadin/flow/component/grid/testbench/GridTRElement.java
@@ -36,7 +36,7 @@ public class GridTRElement extends TestBenchElement {
                         + "return Array.from(grid.children)."
                         + "filter(function(cell) { return cell._column && cell._column.__generatedTbId == columnId;})[0]",
                 this, column.get__generatedId());
-        return e.wrap(GridTHTDElement.class);
+        return e == null ? null : e.wrap(GridTHTDElement.class);
     }
 
     /**
@@ -50,7 +50,7 @@ public class GridTRElement extends TestBenchElement {
                         + "return Array.from(grid.children)."
                         + "filter(function(cell) { return cell.getAttribute('part') && cell.getAttribute('part').includes('cell details-cell');})[0]",
                 this);
-        return e.wrap(GridTHTDElement.class);
+        return e == null ? null : e.wrap(GridTHTDElement.class);
     }
 
     /**

--- a/src/test/java/com/vaadin/flow/component/grid/testbench/TreeGridElement.java
+++ b/src/test/java/com/vaadin/flow/component/grid/testbench/TreeGridElement.java
@@ -236,10 +236,10 @@ public class TreeGridElement extends GridElement {
      * @throws NoSuchElementException
      *             if there is no expand element for this row
      */
-    public WebElement getExpandToggleElement(int rowIndex, int hierarchyColumnIndex) {
-        return getCell(rowIndex, hierarchyColumnIndex)
-                .$("vaadin-grid-tree-toggle").first();
-
+    public WebElement getExpandToggleElement(int rowIndex,
+            int hierarchyColumnIndex) {
+        GridTHTDElement cell = getCell(rowIndex, hierarchyColumnIndex);
+        return cell == null ? null : cell.$("vaadin-grid-tree-toggle").first();
     }
 
     /**
@@ -269,8 +269,7 @@ public class TreeGridElement extends GridElement {
      */
     public long getNumberOfExpandedRows() {
         long value = (long) executeScript(
-                "return arguments[0].expandedItems.length;",
-                this);
+                "return arguments[0].expandedItems.length;", this);
         return value;
     }
 


### PR DESCRIPTION
There was a bug in vaadin-grid 5.2.0 that prevented some of the tests to
work. That was fixed on 5.2.1. Some other fixes on the connector and the
tests had to be made, due to behavior changes of the webcomponent.

The build will only pass after https://github.com/vaadin/flow-component-base/pull/91 has been merged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-flow/384)
<!-- Reviewable:end -->
