### PR TITLE
Fix client side visual de-selection for disabled grid.

### DIFF
--- a/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -129,7 +129,7 @@ window.Vaadin.Flow.gridConnector = {
       if (selectionMode === 'NONE') {
         return;
       }
-      if (userOriginated && (grid.getAttribute('disabled') || grid.getAttribute('disabled') === '')) {
+      if (userOriginated && grid.hasAttribute('disabled')) {
           return;
       }
       if (selectionMode === 'SINGLE') {
@@ -153,6 +153,10 @@ window.Vaadin.Flow.gridConnector = {
     };
 
     grid.$connector.doDeselection = function(item, userOriginated) {
+      if (userOriginated && grid.hasAttribute('disabled')) {
+        return;
+      }
+
       if (selectionMode === 'SINGLE' || selectionMode === 'MULTI') {
         grid.deselectItem(item);
         delete selectedKeys[item.key];

--- a/src/main/resources/META-INF/resources/frontend/vaadin-grid-flow-selection-column.html
+++ b/src/main/resources/META-INF/resources/frontend/vaadin-grid-flow-selection-column.html
@@ -113,6 +113,10 @@
 
       _onSelectAllClick(e) {
         e.preventDefault();
+        if (this._grid.hasAttribute('disabled')) {
+          e.target.checked = !e.target.checked;
+          return;
+        }
         this.selectAll ? this.$server.deselectAll() : this.$server.selectAll();
       }
 


### PR DESCRIPTION
Disable switching of multiselect selectAll button
when grid disabled.

Fixes #379

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-flow/400)
<!-- Reviewable:end -->
