### PR TITLE
Move HierarchicalTestBean to demo package. (#427)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -259,27 +259,6 @@
                     </webApp>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <finalName>${project.artifactId}</finalName>
-                </configuration>
-                <executions>
-                    <execution>
-                        <configuration>
-                            <includes>
-                                <include>**/demo/**</include>
-                                <include>**/HierarchicalTestBean.class</include>
-                            </includes>
-                            <classifier>demo</classifier>
-                        </configuration>
-                        <goals>
-                            <goal>test-jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
     <profiles>

--- a/src/test/java/com/vaadin/flow/component/grid/LazyHierarchicalDataProvider.java
+++ b/src/test/java/com/vaadin/flow/component/grid/LazyHierarchicalDataProvider.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import com.vaadin.flow.component.grid.demo.HierarchicalTestBean;
 import com.vaadin.flow.data.provider.hierarchy.AbstractBackEndHierarchicalDataProvider;
 import com.vaadin.flow.data.provider.hierarchy.HierarchicalQuery;
 

--- a/src/test/java/com/vaadin/flow/component/grid/demo/GridView.java
+++ b/src/test/java/com/vaadin/flow/component/grid/demo/GridView.java
@@ -51,7 +51,6 @@ import com.vaadin.flow.component.grid.GridSortOrder;
 import com.vaadin.flow.component.grid.GridVariant;
 import com.vaadin.flow.component.grid.HeaderRow;
 import com.vaadin.flow.component.grid.HeaderRow.HeaderCell;
-import com.vaadin.flow.component.grid.HierarchicalTestBean;
 import com.vaadin.flow.component.grid.editor.Editor;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Label;

--- a/src/test/java/com/vaadin/flow/component/grid/demo/HierarchicalTestBean.java
+++ b/src/test/java/com/vaadin/flow/component/grid/demo/HierarchicalTestBean.java
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License. 
  */
-package com.vaadin.flow.component.grid;
+package com.vaadin.flow.component.grid.demo;
 
 public class HierarchicalTestBean {
 

--- a/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridBasicFeaturesPage.java
+++ b/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridBasicFeaturesPage.java
@@ -25,7 +25,7 @@ import com.vaadin.flow.component.grid.Grid.SelectionMode;
 import com.vaadin.flow.component.grid.GridMultiSelectionModel;
 import com.vaadin.flow.component.grid.GridMultiSelectionModel.SelectAllCheckboxVisibility;
 import com.vaadin.flow.component.grid.GridSelectionModel;
-import com.vaadin.flow.component.grid.HierarchicalTestBean;
+import com.vaadin.flow.component.grid.demo.HierarchicalTestBean;
 import com.vaadin.flow.component.grid.LazyHierarchicalDataProvider;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;

--- a/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridScrollingPage.java
+++ b/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridScrollingPage.java
@@ -15,7 +15,7 @@
  */
 package com.vaadin.flow.component.treegrid.it;
 
-import com.vaadin.flow.component.grid.HierarchicalTestBean;
+import com.vaadin.flow.component.grid.demo.HierarchicalTestBean;
 import com.vaadin.flow.component.grid.LazyHierarchicalDataProvider;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.treegrid.TreeGrid;


### PR DESCRIPTION
Moving the Bean to the demo package as it's
used in the demo and other tests can use it from there
also as needed.

This will make the demo build much less brittle due to
changes to the parent project.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-flow/428)
<!-- Reviewable:end -->
