### PR TITLE
Properly clear client caches when collapsing TreeGrid

### DIFF
--- a/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -435,8 +435,11 @@ window.Vaadin.Flow.gridConnector = {
       } else {
         delete cache[parentKey];
         let parentCache = grid.$connector.getCacheByKey(parentKey);
-        if(parentCache && parentCache.itemkeyCaches && parentCache.itemkeyCaches[parentKey]) {
-          parentCache.itemkeyCaches[parentKey].items = [];
+        if (parentCache && parentCache.itemkeyCaches && parentCache.itemkeyCaches[parentKey]) {
+          delete parentCache.itemkeyCaches[parentKey];
+        }
+        if (parentCache && parentCache.itemCaches && parentCache.itemCaches[parentKey]) {
+          delete parentCache.itemCaches[parentKey];
         }
         delete lastRequestedRanges[parentKey];
 

--- a/src/test/java/com/vaadin/flow/component/grid/it/GridFilteringIT.java
+++ b/src/test/java/com/vaadin/flow/component/grid/it/GridFilteringIT.java
@@ -38,7 +38,6 @@ public class GridFilteringIT extends AbstractComponentIT {
         // Blur input to get value change
         executeScript("arguments[0].blur();", input);
 
-
         WebElement grid = findElement(By.id("data-grid"));
         // empty Grid content
         Object size = executeScript("return arguments[0].size", grid);
@@ -52,6 +51,6 @@ public class GridFilteringIT extends AbstractComponentIT {
         waitUntil(driver -> executeScript("return arguments[0].size", grid)
                 .toString().equals("3"));
 
-        waitUntil(driver -> grid.getAttribute("loading") == null);
+        waitUntil(driver -> "false".equals(grid.getAttribute("loading")));
     }
 }


### PR DESCRIPTION
Fix the failing ITs (also the one about filtering)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-flow/441)
<!-- Reviewable:end -->
