### PR TITLE
Fixing a build failure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -241,7 +241,13 @@
             <version>1.3</version>
             <scope>test</scope>
         </dependency>
-        
+
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-osgi</artifactId>
+            <version>${flow.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Adding a dependency on `flow-osgi` to fix `NoClassDefFoundError` for the  interface `OsgiVaadinStaticResource` in `GridSerializableTest`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-flow/442)
<!-- Reviewable:end -->
