### PR TITLE
Fix unnecessary DOM updates for grid

### DIFF
--- a/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -1284,7 +1284,7 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
                 CompositeDataGenerator<T> dataGenerator, U arrayUpdater,
                 SerializableSupplier<ValueProvider<T, String>> uniqueKeyProviderSupplier) {
             return new DataCommunicator<>(dataGenerator, arrayUpdater,
-                    data -> element.callFunction("$connector.updateData", data),
+                    data -> element.callFunction("$connector.updateFlatData", data),
                     element.getNode());
         }
     }

--- a/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
+++ b/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
@@ -201,7 +201,7 @@ public class TreeGrid<T> extends Grid<T>
 
             return new HierarchicalDataCommunicator<>(dataGenerator,
                     arrayUpdater,
-                    data -> element.callFunction("$connector.updateData", data),
+                    data -> element.callFunction("$connector.updateHierarchicalData", data),
                     element.getNode(), uniqueKeyProviderSupplier);
         }
     }

--- a/src/test/java/com/vaadin/flow/component/grid/it/GridItemRefreshPage.java
+++ b/src/test/java/com/vaadin/flow/component/grid/it/GridItemRefreshPage.java
@@ -24,6 +24,9 @@ import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Label;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.data.renderer.ComponentRenderer;
+import com.vaadin.flow.data.renderer.NativeButtonRenderer;
+import com.vaadin.flow.data.renderer.Renderer;
+import com.vaadin.flow.data.renderer.TemplateRenderer;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.theme.NoTheme;
 
@@ -34,13 +37,20 @@ public class GridItemRefreshPage extends Div {
     public static final String UPDATED_FIRST_FIELD = "updated";
     public static final int UPDATED_SECOND_FIELD = 12345;
 
+    // update the element values from client side so that it should only be updated in DOM, not in caches
+    // updating the previous cell in animation frame so that grid active item handling doesn't reset the changes
+    private static final String EDIT_CELL_VALUE = "debugger; this['innerText'] = 'EDITED';window.requestAnimationFrame(() => {this.parentElement.previousElementSibling['textContent']='EDITED';})";
+    private static final TemplateRenderer<Bean> UPDATE_RENDERER = TemplateRenderer.of("<div id=[[item.thirdField]] onclick=\"" + EDIT_CELL_VALUE + "\">[[item.thirdField]]</div>");
+
     private static class Bean {
         private String firstField;
         private int secondField;
+        private final String thirdField;
 
         public Bean(String firstField, int secondField) {
             this.firstField = firstField;
             this.secondField = secondField;
+            this.thirdField = "div-"+secondField;
         }
 
         public String getFirstField() {
@@ -58,6 +68,10 @@ public class GridItemRefreshPage extends Div {
         public void setSecondField(int secondField) {
             this.secondField = secondField;
         }
+
+        public String getThirdField() {
+            return thirdField;
+        }
     }
 
     public GridItemRefreshPage() {
@@ -70,7 +84,8 @@ public class GridItemRefreshPage extends Div {
         grid.setHeight("500px");
         grid.addColumn(Bean::getFirstField).setHeader("First Field");
         grid.addColumn(Bean::getSecondField).setHeader("Second Field");
-        List<Bean> items = createItems(1000);
+        grid.addColumn(UPDATE_RENDERER.withProperty("thirdField", bean -> bean.thirdField)).setHeader("mutation");
+      List<Bean> items = createItems(1000);
         grid.setItems(items);
         grid.setId("template-grid");
 
@@ -100,24 +115,24 @@ public class GridItemRefreshPage extends Div {
     }
 
     private void addButtons(Grid<Bean> grid, List<Bean> items,
-            String idPrefix) {
+                            String idPrefix) {
         NativeButton refreshFirstBtn = new NativeButton(
                 "update and refresh first item", event -> {
-                    updateBean(items.get(0));
-                    grid.getDataProvider().refreshItem(items.get(0));
-                });
+            updateBean(items.get(0));
+            grid.getDataProvider().refreshItem(items.get(0));
+        });
         NativeButton refreshMultipleBtn = new NativeButton(
                 "update and refresh items 5-10", event -> {
-                    items.subList(4, 10).forEach(item -> {
-                        updateBean(item);
-                        grid.getDataProvider().refreshItem(item);
-                    });
-                });
+            items.subList(4, 10).forEach(item -> {
+                updateBean(item);
+                grid.getDataProvider().refreshItem(item);
+            });
+        });
         NativeButton refreshProviderBtn = new NativeButton(
                 "refresh all through data provider", event -> {
-                    items.forEach(this::updateBean);
-                    grid.getDataProvider().refreshAll();
-                });
+            items.forEach(this::updateBean);
+            grid.getDataProvider().refreshAll();
+        });
 
         NativeButton refreshFirstCommunicatorBtn = new NativeButton(
                 "update and refresh first item through data communicator",
@@ -135,9 +150,9 @@ public class GridItemRefreshPage extends Div {
                 });
         NativeButton resetCommunicatorBtn = new NativeButton(
                 "refresh all through data communicator", event -> {
-                    items.forEach(this::updateBean);
-                    grid.getDataCommunicator().reset();
-                });
+            items.forEach(this::updateBean);
+            grid.getDataCommunicator().reset();
+        });
 
         refreshFirstBtn.setId(idPrefix + "refresh-first");
         refreshMultipleBtn.setId(idPrefix + "refresh-multiple");


### PR DESCRIPTION
Update only refreshed items in the DOM instead of all items every single
time and multiple times per each update. grid._assignModels(...) now takes
the updated items, when called without parameters, it refreshes every
single row. This has caused some performance overhead for slower
browsers.

Fixes #419

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-flow/485)
<!-- Reviewable:end -->
