### PR TITLE
Refresh on client-side events only

### DIFF
--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridView.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridView.java
@@ -1593,7 +1593,10 @@ public class GridView extends DemoView {
         // This is needed for the email column to turn into nothing when the
         // checkbox is deselected, for example.
         binder.addValueChangeListener(event -> {
-            grid.getEditor().refresh();
+            // Only updates from the client-side should be taken into account
+            if (event.isFromClient()) {
+                grid.getEditor().refresh();
+            }
         });
 
         grid.addItemClickListener(event -> {


### PR DESCRIPTION
Double-clicking on rows in Unbuffered dynamic editor demo caused ever-increasing delays to opening the editor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-flow/548)
<!-- Reviewable:end -->
