### PR TITLE
Hidden select column api

### DIFF
--- a/vaadin-grid-flow-demo/src/main/java/com/vaadin/flow/component/grid/demo/GridDemo.java
+++ b/vaadin-grid-flow-demo/src/main/java/com/vaadin/flow/component/grid/demo/GridDemo.java
@@ -904,8 +904,11 @@ public class GridDemo extends DemoView {
         grid.asMultiSelect().select(personList.get(0), personList.get(1));
         // end-source-example
         grid.setId("multi-selection");
+        Checkbox selColVisibleCB = new Checkbox("Show Selection Column");
+        selColVisibleCB.setValue(true);
+        selColVisibleCB.addValueChangeListener(ev -> ((GridMultiSelectionModel)grid.getSelectionModel()).setSelectionColumnVisible(ev.getValue()));
         messageDiv.setId("multi-selection-message");
-        addCard("Selection", "Grid Multi Selection", grid, messageDiv);
+        addCard("Selection", "Grid Multi Selection", grid, selColVisibleCB, messageDiv);
     }
 
     private void createProgrammaticSelect() {

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridMultiSelectionColumnPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridMultiSelectionColumnPage.java
@@ -18,11 +18,15 @@ package com.vaadin.flow.component.grid.it;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.grid.Grid.SelectionMode;
+import com.vaadin.flow.component.grid.GridMultiSelectionModel;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H2;
 import com.vaadin.flow.component.html.NativeButton;
@@ -52,6 +56,7 @@ public class GridMultiSelectionColumnPage extends Div {
 
         createLazyGrid();
         createInMemoryGrid();
+        createInMemoryGridWithNoSelectColumn();
         createGridWithSwappedDataProvider();
 
         add(message);
@@ -78,6 +83,24 @@ public class GridMultiSelectionColumnPage extends Div {
         setUp(grid);
         grid.setId("in-memory-grid");
         add(new H2("In-memory grid"), grid);
+    }
+
+    private void createInMemoryGridWithNoSelectColumn() {
+        Grid<String> grid = new Grid<>();
+        grid.setItems(
+                IntStream.range(0, ITEM_COUNT).mapToObj(Integer::toString));
+        setUp(grid);
+        ((GridMultiSelectionModel)grid.getSelectionModel()).setSelectionColumnVisible(false);
+        grid.setId("in-memory-grid-no-select");
+        Button addSelect = new Button("Add Selection", event -> {
+            Set<Integer> selIns = grid.asMultiSelect().getSelectedItems().stream().map(Integer::parseInt).collect(Collectors.toSet());
+            IntStream.range(0, ITEM_COUNT).filter(i -> !selIns.contains(i)).findFirst().ifPresent(i -> {
+                selIns.add(i);
+                grid.asMultiSelect().select(selIns.stream().map(Object::toString).collect(Collectors.toList()));
+            });
+        });
+        addSelect.setId("in-memory-add-select-button");
+        add(new H2("In-memory grid with no select column"), grid, addSelect);
     }
 
     private void createGridWithSwappedDataProvider() {

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridMultiSelectionColumnPageIT.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridMultiSelectionColumnPageIT.java
@@ -79,6 +79,33 @@ public class GridMultiSelectionColumnPageIT extends AbstractComponentIT {
     }
 
     @Test
+    public void hiddenSelectColumn() {
+        open();
+
+        WebElement grid = findElement(By.id("in-memory-grid-no-select"));
+        WebElement selectAllCheckbox = grid
+                .findElement(By.id("selectAllCheckbox"));
+        Assert.assertFalse(
+                "selectAllCheckbox should not be displayed for this test",
+                selectAllCheckbox.isDisplayed());
+
+        WebElement message = findElement(By.id("selected-item-count"));
+
+        WebElement addSelButton = findElement(By.id("in-memory-add-select-button"));
+
+        for (int i = 0; i < 5; ++i) {
+            addSelButton.click();
+            Assert.assertEquals(
+                    "Selected item count: "+ (i+1),
+                    message.getText());
+            WebElement selectCheckbox = grid
+                    .findElements(By.tagName("vaadin-checkbox")).get(i);
+            Assert.assertFalse("Row checkbox should not be visible", selectCheckbox.isDisplayed());
+        }
+
+    }
+
+    @Test
     public void gridWithSwappedDataProvider_selectAllIsNotVisible_swapingDataProvidersChangeItsState() {
         open();
 

--- a/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModel.java
+++ b/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/AbstractGridMultiSelectionModel.java
@@ -406,4 +406,14 @@ public abstract class AbstractGridMultiSelectionModel<T>
         removedItems.forEach(getGrid().getDataCommunicator()::refresh);
         getGrid().doClientSideDeselection(removedItems);
     }
+
+    @Override
+    public void setSelectionColumnVisible(boolean visible) {
+        selectionColumn.setVisible(visible);
+    }
+
+    @Override
+    public boolean isSelectionColumnVisible() {
+        return selectionColumn.isVisible();
+    }
 }

--- a/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridMultiSelectionModel.java
+++ b/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridMultiSelectionModel.java
@@ -137,4 +137,19 @@ public interface GridMultiSelectionModel<T>
      * @return whether the selection column is frozen
      */
     boolean isSelectionColumnFrozen();
+
+    /**
+     * Sets the selection column's visible state (default: true).
+     *
+     * @param visible
+     *            whether to display or not the selection column
+     */
+    void setSelectionColumnVisible(boolean visible);
+
+    /**
+     * Gets the the selection column's visible state.
+     *
+     * @return whether the selection column is visible
+     */
+    boolean isSelectionColumnVisible();
 }


### PR DESCRIPTION
This feature was born from a request from my organization's design team.
The team expects multi-selection tables to NOT show the selection column, using instead a context menu or key shortcut which will select and unselect rows programmatically.

The implementation I am asking to merge into Grid Flow adds a simple call to allow developers to hide that column if they so choose.

Note that developers not interested in this feature do not have to do any changes in their current code, as the default after this change is to show the selection column.
See also demo and IT.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-flow/555)
<!-- Reviewable:end -->
