### PR TITLE
Add a test tht checks that flow-component-renderer doesn't throw if text node is used

### DIFF
--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/TextInsideComponentRendererPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/TextInsideComponentRendererPage.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.it;
+
+import com.vaadin.flow.component.Text;
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.data.renderer.ComponentRenderer;
+import com.vaadin.flow.router.Route;
+
+@Route("text-component-renderer")
+public class TextInsideComponentRendererPage extends Div {
+
+    public TextInsideComponentRendererPage() {
+        Grid<String> grid = new Grid<>();
+
+        grid.addColumn(new ComponentRenderer<>(line -> new Text(line)))
+                .setHeader("Name");
+        grid.setItems("foo", "bar");
+
+        add(grid);
+    }
+
+}

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/TextInsideComponentRendererIT.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/TextInsideComponentRendererIT.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.it;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import com.vaadin.flow.testutil.AbstractComponentIT;
+import com.vaadin.flow.testutil.TestPath;
+
+@TestPath("text-component-renderer")
+public class TextInsideComponentRendererIT extends AbstractComponentIT {
+
+    @Test
+    public void renderGrid_noClientSideExceptions() {
+        open();
+
+        Assert.assertFalse(isElementPresent(By.className("v-system-error")));
+        checkLogsForErrors();
+    }
+}


### PR DESCRIPTION
Test for flow#5206

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-flow/577)
<!-- Reviewable:end -->
