### PR TITLE
Test add rows containing components added with flow-component-renderer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -204,7 +204,18 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-combo-box-flow</artifactId>
+            <version>2.1-SNAPSHOT</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.webjars.bowergithub.polymerelements</groupId>
+                    <artifactId>iron-flex-layout</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>

--- a/src/test/java/com/vaadin/flow/component/grid/it/GridComponentRendererIT.java
+++ b/src/test/java/com/vaadin/flow/component/grid/it/GridComponentRendererIT.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2000-2019 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.component.grid.it;
+
+import com.vaadin.flow.component.grid.testbench.GridElement;
+import com.vaadin.flow.component.grid.testbench.GridTHTDElement;
+import com.vaadin.flow.testutil.AbstractComponentIT;
+import com.vaadin.flow.testutil.TestPath;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+@TestPath("grid-component-renderer")
+public class GridComponentRendererIT extends AbstractComponentIT {
+
+    private GridElement grid;
+    private WebElement adRowButton;
+
+    @Before
+    public void init() {
+        open();
+
+        waitForElementPresent(By.id("add-row-button"));
+        adRowButton = this.findElement(By.id("add-row-button"));
+
+        waitForElementPresent(By.id("grid"));
+        grid = $(GridElement.class).id("grid");
+
+
+    }
+
+    @Test
+    public void addRowWithComponents_all_components_are_visible(){
+
+        GridTHTDElement cell;
+
+        for(int rowIndex = 0; rowIndex < 10; rowIndex ++){
+            clickElementWithJs(adRowButton);
+
+            cell = grid.getCell(grid.getRowCount() - 1, 0);
+            Assert.assertTrue("TextField is not present!", cell.$("vaadin-text-field").exists());
+            Assert.assertTrue("TextField is not displayed!", cell.$("vaadin-text-field").first().isDisplayed());
+
+            for(int colIndex = 1; colIndex < 5; colIndex++){
+                cell = grid.getCell(grid.getRowCount() - 1, colIndex);
+                Assert.assertTrue("Combobox is not present!", cell.$("vaadin-combo-box").exists());
+                Assert.assertTrue("Combobox is not displayed!", cell.$("vaadin-combo-box").first().isDisplayed());
+            }
+        }
+        System.out.println();
+
+
+    }
+}

--- a/src/test/java/com/vaadin/flow/component/grid/it/GridComponentRendererPage.java
+++ b/src/test/java/com/vaadin/flow/component/grid/it/GridComponentRendererPage.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2000-2019 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.component.grid.it;
+
+import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.textfield.TextField;
+import com.vaadin.flow.data.renderer.ComponentRenderer;
+import com.vaadin.flow.function.SerializableBiConsumer;
+import com.vaadin.flow.router.Route;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Test view that adds rows with components to a Grid.
+ *
+ * Page that reproduces the bug described at
+ * https://github.com/vaadin/vaadin-grid-flow/issues/557
+ *
+ */
+@Route("grid-component-renderer")
+public class GridComponentRendererPage extends Div {
+
+    public GridComponentRendererPage() {
+        final List<String> items = new ArrayList<>();
+        AtomicInteger index = new AtomicInteger(1);
+
+        Grid<String> grid = new Grid<>();
+        grid.setId("grid");
+        grid.setItems(items);
+
+        SerializableBiConsumer<TextField, String> itemTextFieldConsumer =(text, val) -> {
+            text.setId("vaadin-text-field-" +index.getAndIncrement());
+        };
+
+        SerializableBiConsumer<ComboBox<String>, String> itemComboBoxConsumer = (comboBox, val) -> {
+            comboBox.setId("vaadin-combo-box-" + index.getAndIncrement());
+        };
+
+        grid.addColumn(new ComponentRenderer<>(TextField::new, itemTextFieldConsumer)).setHeader("Header 1");
+        grid.addColumn(new ComponentRenderer<>(ComboBox<String>::new, itemComboBoxConsumer)).setHeader("Header 2");
+        grid.addColumn(new ComponentRenderer<>(ComboBox<String>::new, itemComboBoxConsumer)).setHeader("Header 3");
+        grid.addColumn(new ComponentRenderer<>(ComboBox<String>::new, itemComboBoxConsumer)).setHeader("Header 4");
+        grid.addColumn(new ComponentRenderer<>(ComboBox<String>::new, itemComboBoxConsumer)).setHeader("Header 5");
+
+        NativeButton addRowButton = new NativeButton("add row", event -> {
+            items.add(index.getAndIncrement() + "");
+            grid.getDataProvider().refreshAll();
+        });
+        addRowButton.setId("add-row-button");
+        add(addRowButton, grid);
+
+    }
+}


### PR DESCRIPTION
This PR adds an integration test to make sure that when the grid has component renderer columns, all components are visible on grid each time a new row is added.

Testing the fix introduced with [PR 5223](https://github.com/vaadin/flow/pull/5223) for issue [vaadin/vaadin-grid-flow/issues/557](https://github.com/vaadin/vaadin-grid-flow/issues/557)