### PR TITLE
Bump context-menu version and update tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,11 +14,11 @@
     <version>3.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Vaadin Grid Flow Parent</name>
-    
+
 
     <properties>
         <flow.version>1.5-SNAPSHOT</flow.version>
-        <contextmenu.version>2.0-SNAPSHOT</contextmenu.version>
+        <contextmenu.version>2.1-SNAPSHOT</contextmenu.version>
         <testbench.version>6.0.1</testbench.version>
         <jetty.plugin.version>9.4.11.v20180605</jetty.plugin.version>
         <maven.compiler.source>1.8</maven.compiler.source>
@@ -26,7 +26,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
-    
+
     <modules>
         <module>vaadin-grid-flow</module>
         <module>vaadin-grid-flow-testbench</module>
@@ -39,7 +39,7 @@
             <url>http://maven.vaadin.com/vaadin-prereleases</url>
         </pluginRepository>
     </pluginRepositories>
-    
+
     <repositories>
         <repository>
             <id>vaadin-prereleases</id>

--- a/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/contextmenu/GridContextMenuTest.java
+++ b/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/contextmenu/GridContextMenuTest.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.component.grid.contextmenu;
 
+import java.util.Optional;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -30,6 +32,7 @@ import com.vaadin.flow.dom.DomListenerRegistration;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.SerializableRunnable;
 import com.vaadin.flow.internal.StateNode;
+import com.vaadin.flow.shared.Registration;
 
 public class GridContextMenuTest {
 
@@ -97,10 +100,15 @@ public class GridContextMenuTest {
 
         DomListenerRegistration registration = Mockito
                 .mock(DomListenerRegistration.class);
-
         Mockito.when(
                 element.addEventListener(Mockito.anyString(), Mockito.any()))
                 .thenReturn(registration);
+
+        Mockito.when(grid.getUI()).thenReturn(Optional.empty());
+
+        Registration attachRegistration = Mockito.mock(Registration.class);
+        Mockito.when(grid.addAttachListener(Mockito.any()))
+                .thenReturn(attachRegistration);
 
         GridContextMenu gridContextMenu = new GridContextMenu<>();
         gridContextMenu.setTarget(grid);


### PR DESCRIPTION
One unit test needed more mocking because of internal changes in
ContextMenuBase::setTarget

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-flow/596)
<!-- Reviewable:end -->
