### PR TITLE
Refactor gridConnector to use getEventContext API

### DIFF
--- a/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -98,7 +98,7 @@ window.Vaadin.Flow.gridConnector = {
 
     grid.size = 0; // To avoid NaN here and there before we get proper data
     grid.itemIdPath = 'key';
-    
+
     grid.$connector = {};
 
     grid.$connector.hasEnsureSubCacheQueue = function() {
@@ -108,7 +108,7 @@ window.Vaadin.Flow.gridConnector = {
     grid.$connector.hasParentRequestQueue = function() {
         return parentRequestQueue.length > 0;
     }
-    
+
     grid.$connector.beforeEnsureSubCacheForScaledIndex = function(targetCache, scaledIndex) {
       // add call to queue
       ensureSubCacheQueue.push({
@@ -884,68 +884,26 @@ window.Vaadin.Flow.gridConnector = {
     }
 
     const contextMenuListener = function(e) {
-      // https://github.com/vaadin/vaadin-grid/issues/1318
-      const path = e.composedPath();
-      const index = path.indexOf(grid.$.table);
-      const row = path[index - 2]; // <tr> element in shadow dom
-      const cell = path[index - 3]; // cell element
-      let key;
-      let colId;
-      if (row && row._item) {
-        key = row._item.key;
-      }
-      if (cell && cell._column) {
-        colId = cell._column.id;
-      }
+      const eventContext = grid.getEventContext(e);
+      const key = eventContext.item && eventContext.item.key;
+      const colId = eventContext.column && eventContext.column.id;
       grid.$server.updateContextMenuTargetItem(key, colId);
     }
 
     grid.addEventListener('vaadin-context-menu-before-open', function(e) {
       contextMenuListener(grid.$contextMenuConnector.openEvent);
     });
-    
-    function _runWhenReady(){
-        if ( grid.$ ){
-            grid.$.scroller.addEventListener('click', _onClick);
-            grid.$.scroller.addEventListener('dblclick', _onDblClick);
-            grid.addEventListener('cell-activate', _cellActivated);
-        }
-        else {
-            window.setTimeout(_runWhenReady, 0 );
-        }
-    }
-    
-    _runWhenReady();
-    
-    function _cellActivated(event){
-        grid.$connector.clickedItem = event.detail.model.item;
-    }
-    
-    function _onClick(event){
-        _fireClickEvent(event, 'item-click');
-    }
-    
-    function _onDblClick(event){
-        _fireClickEvent(event, 'item-double-click');
-    }
-    
-    function _fireClickEvent(event, eventName){
-        // if there was no click on item then don't do anything
-        if (grid.$connector.clickedItem){
-            event.itemKey = grid.$connector.clickedItem.key;
-            grid.dispatchEvent(new CustomEvent(eventName, 
-                    { 
-                        detail: event
-                    }));
-            // can't clear the clicked item right away since there may be 
-            // not handled double click event (or may be not, it's not known)
-            // schedule this for the next cycle
-            window.setTimeout(_clearClickedItem, 0 );
-        }
-    }
-    
-    function _clearClickedItem(){
-        grid.$connector.clickedItem = null;
+
+    grid.addEventListener('click', e => _fireClickEvent(e, 'item-click'));
+    grid.addEventListener('dblclick', e => _fireClickEvent(e, 'item-double-click'));
+
+    function _fireClickEvent(event, eventName) {
+      const item = grid.getEventContext(event).item;
+      if (item) {
+        event.itemKey = item.key;
+        grid.dispatchEvent(new CustomEvent(eventName,
+          { detail: event }));
+      }
     }
 
     grid.$connector.columnToIdMap = new Map();


### PR DESCRIPTION
With the proper web component API to retrieve item and column data from
events, we can reduce the amount of code, complexity and usage of
private APIs.

Fix #439

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-flow/608)
<!-- Reviewable:end -->
