### PR TITLE
Removed @NoTheme annotations from ITs

### DIFF
--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/BeanGridSortingPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/BeanGridSortingPage.java
@@ -22,7 +22,6 @@ import com.vaadin.flow.router.Route;
 import com.vaadin.flow.theme.NoTheme;
 
 @Route("bean-grid-sorting")
-@NoTheme
 public class BeanGridSortingPage extends Div {
 
     public BeanGridSortingPage() {

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/BeanGridSortingPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/BeanGridSortingPage.java
@@ -19,7 +19,6 @@ import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.data.bean.Person;
 import com.vaadin.flow.router.Route;
-import com.vaadin.flow.theme.NoTheme;
 
 @Route("bean-grid-sorting")
 public class BeanGridSortingPage extends Div {

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/ButtonInGridPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/ButtonInGridPage.java
@@ -22,7 +22,6 @@ import com.vaadin.flow.router.Route;
 import com.vaadin.flow.theme.NoTheme;
 
 @Route("vaadin-button-inside-grid")
-@NoTheme
 public class ButtonInGridPage extends Div {
 
     public ButtonInGridPage() {

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/ButtonInGridPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/ButtonInGridPage.java
@@ -19,7 +19,6 @@ import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.router.Route;
-import com.vaadin.flow.theme.NoTheme;
 
 @Route("vaadin-button-inside-grid")
 public class ButtonInGridPage extends Div {

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/DisabledGridPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/DisabledGridPage.java
@@ -26,7 +26,6 @@ import com.vaadin.flow.router.Route;
 import com.vaadin.flow.theme.NoTheme;
 
 @Route("disabled-grid")
-@NoTheme
 public class DisabledGridPage extends Div {
 
     private Div message;

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/DisabledGridPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/DisabledGridPage.java
@@ -23,7 +23,6 @@ import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.data.renderer.NativeButtonRenderer;
 import com.vaadin.flow.function.ValueProvider;
 import com.vaadin.flow.router.Route;
-import com.vaadin.flow.theme.NoTheme;
 
 @Route("disabled-grid")
 public class DisabledGridPage extends Div {

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridDelegateFocusToComponentPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridDelegateFocusToComponentPage.java
@@ -25,7 +25,6 @@ import com.vaadin.flow.router.Route;
 import com.vaadin.flow.theme.NoTheme;
 
 @Route("delegate-focus-inside-component-renderer")
-@NoTheme
 public class GridDelegateFocusToComponentPage extends Div {
 
     public GridDelegateFocusToComponentPage() {

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridDelegateFocusToComponentPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridDelegateFocusToComponentPage.java
@@ -22,7 +22,6 @@ import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.router.Route;
-import com.vaadin.flow.theme.NoTheme;
 
 @Route("delegate-focus-inside-component-renderer")
 public class GridDelegateFocusToComponentPage extends Div {

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridEditorFocusPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridEditorFocusPage.java
@@ -29,6 +29,9 @@
 
 package com.vaadin.flow.component.grid.it;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.grid.editor.Editor;
 import com.vaadin.flow.component.html.Div;
@@ -38,8 +41,6 @@ import com.vaadin.flow.data.bean.Person;
 import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.data.provider.ListDataProvider;
 import com.vaadin.flow.router.Route;
-import java.util.ArrayList;
-import java.util.List;
 
 @Route("editor-focus")
 public class GridEditorFocusPage extends Div {

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridFilteringPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridFilteringPage.java
@@ -18,7 +18,6 @@ import com.vaadin.flow.router.Route;
 import com.vaadin.flow.theme.NoTheme;
 
 @Route("grid-filtering")
-@NoTheme
 public class GridFilteringPage extends Div {
 
     private static final Set<String> DATA = getData();

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridFilteringPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridFilteringPage.java
@@ -15,7 +15,6 @@ import com.vaadin.flow.data.provider.CallbackDataProvider;
 import com.vaadin.flow.data.provider.ConfigurableFilterDataProvider;
 import com.vaadin.flow.data.provider.DataProvider;
 import com.vaadin.flow.router.Route;
-import com.vaadin.flow.theme.NoTheme;
 
 @Route("grid-filtering")
 public class GridFilteringPage extends Div {

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridFullSizeInATemplatePage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridFullSizeInATemplatePage.java
@@ -19,7 +19,6 @@ import java.util.Arrays;
 
 import com.vaadin.flow.function.ValueProvider;
 import com.vaadin.flow.router.Route;
-import com.vaadin.flow.theme.NoTheme;
 
 @Route("grid-with-full-size-in-template")
 public class GridFullSizeInATemplatePage extends GridInATemplate {

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridFullSizeInATemplatePage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridFullSizeInATemplatePage.java
@@ -22,7 +22,6 @@ import com.vaadin.flow.router.Route;
 import com.vaadin.flow.theme.NoTheme;
 
 @Route("grid-with-full-size-in-template")
-@NoTheme
 public class GridFullSizeInATemplatePage extends GridInATemplate {
 
     public GridFullSizeInATemplatePage() {

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridHeaderFooterRowPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridHeaderFooterRowPage.java
@@ -36,7 +36,6 @@ import com.vaadin.flow.theme.NoTheme;
  * Test view that adds header and footer rows to Grid after rendering.
  */
 @Route("grid-header-footer-rows")
-@NoTheme
 public class GridHeaderFooterRowPage extends Div {
 
     int counter = 0;

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridHeaderFooterRowPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridHeaderFooterRowPage.java
@@ -30,7 +30,6 @@ import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.ValueProvider;
 import com.vaadin.flow.router.Route;
-import com.vaadin.flow.theme.NoTheme;
 
 /**
  * Test view that adds header and footer rows to Grid after rendering.

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridHeaderRowWithComponentsPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridHeaderRowWithComponentsPage.java
@@ -31,7 +31,6 @@ import com.vaadin.flow.theme.NoTheme;
  * Test view that adds header rows with components to a Grid.
  */
 @Route("grid-header-row-with-components")
-@NoTheme
 public class GridHeaderRowWithComponentsPage extends Div {
 
     public GridHeaderRowWithComponentsPage() {

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridHeaderRowWithComponentsPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridHeaderRowWithComponentsPage.java
@@ -25,7 +25,6 @@ import com.vaadin.flow.component.html.Label;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.function.ValueProvider;
 import com.vaadin.flow.router.Route;
-import com.vaadin.flow.theme.NoTheme;
 
 /**
  * Test view that adds header rows with components to a Grid.

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridItemRefreshPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridItemRefreshPage.java
@@ -29,7 +29,6 @@ import com.vaadin.flow.router.Route;
 import com.vaadin.flow.theme.NoTheme;
 
 @Route("grid-item-refresh-page")
-@NoTheme
 public class GridItemRefreshPage extends Div {
 
     public static final String UPDATED_FIRST_FIELD = "updated";

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridItemRefreshPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridItemRefreshPage.java
@@ -26,7 +26,6 @@ import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.data.renderer.ComponentRenderer;
 import com.vaadin.flow.data.renderer.TemplateRenderer;
 import com.vaadin.flow.router.Route;
-import com.vaadin.flow.theme.NoTheme;
 
 @Route("grid-item-refresh-page")
 public class GridItemRefreshPage extends Div {

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridLoadsItemsPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridLoadsItemsPage.java
@@ -9,7 +9,6 @@ import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.data.provider.DataProvider;
 import com.vaadin.flow.router.Route;
-import com.vaadin.flow.theme.NoTheme;
 
 @Route("grid-loads-items")
 public class GridLoadsItemsPage extends Div {

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridLoadsItemsPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridLoadsItemsPage.java
@@ -12,7 +12,6 @@ import com.vaadin.flow.router.Route;
 import com.vaadin.flow.theme.NoTheme;
 
 @Route("grid-loads-items")
-@NoTheme
 public class GridLoadsItemsPage extends Div {
     public GridLoadsItemsPage() {
         Grid<String> grid = new Grid<>();

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridMultiSelectionColumnPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridMultiSelectionColumnPage.java
@@ -30,7 +30,6 @@ import com.vaadin.flow.data.provider.CallbackDataProvider;
 import com.vaadin.flow.data.provider.DataProvider;
 import com.vaadin.flow.data.provider.Query;
 import com.vaadin.flow.router.Route;
-import com.vaadin.flow.theme.NoTheme;
 
 /**
  * Test view for grid's multi selection column.

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridMultiSelectionColumnPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridMultiSelectionColumnPage.java
@@ -36,7 +36,6 @@ import com.vaadin.flow.theme.NoTheme;
  * Test view for grid's multi selection column.
  */
 @Route("grid-multi-selection-column")
-@NoTheme
 public class GridMultiSelectionColumnPage extends Div {
 
     public static final int ITEM_COUNT = 1000;

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridOnFlexLayoutPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridOnFlexLayoutPage.java
@@ -24,7 +24,6 @@ import com.vaadin.flow.router.Route;
 import com.vaadin.flow.theme.NoTheme;
 
 @Route("grid-on-flex-layout")
-@NoTheme
 public class GridOnFlexLayoutPage extends FlexLayout {
 
     public GridOnFlexLayoutPage() {

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridOnFlexLayoutPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridOnFlexLayoutPage.java
@@ -21,7 +21,6 @@ import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.orderedlayout.FlexLayout;
 import com.vaadin.flow.function.ValueProvider;
 import com.vaadin.flow.router.Route;
-import com.vaadin.flow.theme.NoTheme;
 
 @Route("grid-on-flex-layout")
 public class GridOnFlexLayoutPage extends FlexLayout {

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridPageSizePage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridPageSizePage.java
@@ -25,7 +25,6 @@ import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.data.provider.DataProvider;
 import com.vaadin.flow.data.provider.Query;
 import com.vaadin.flow.router.Route;
-import com.vaadin.flow.theme.NoTheme;
 
 /**
  * Test view that uses Grid with different pageSize settings.

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridPageSizePage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridPageSizePage.java
@@ -31,7 +31,6 @@ import com.vaadin.flow.theme.NoTheme;
  * Test view that uses Grid with different pageSize settings.
  */
 @Route("grid-page-size")
-@NoTheme
 public class GridPageSizePage extends Div {
 
     private DataProvider<String, ?> dataProvider = DataProvider.fromCallbacks(

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridSerializationPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridSerializationPage.java
@@ -26,7 +26,6 @@ import com.vaadin.flow.router.Route;
 import com.vaadin.flow.theme.NoTheme;
 
 @Route("grid-serialization-page")
-@NoTheme
 public class GridSerializationPage extends Div {
 
     public static class Pojo {

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridSerializationPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridSerializationPage.java
@@ -23,7 +23,6 @@ import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.function.ValueProvider;
 import com.vaadin.flow.router.Route;
-import com.vaadin.flow.theme.NoTheme;
 
 @Route("grid-serialization-page")
 public class GridSerializationPage extends Div {

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridStylingPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridStylingPage.java
@@ -23,7 +23,6 @@ import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.router.Route;
-import com.vaadin.flow.theme.NoTheme;
 
 @Route("grid-styling")
 public class GridStylingPage extends Div {

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridStylingPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridStylingPage.java
@@ -26,7 +26,6 @@ import com.vaadin.flow.router.Route;
 import com.vaadin.flow.theme.NoTheme;
 
 @Route("grid-styling")
-@NoTheme
 public class GridStylingPage extends Div {
 
     public GridStylingPage() {

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridUpdateDataProviderPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridUpdateDataProviderPage.java
@@ -25,7 +25,6 @@ import com.vaadin.flow.component.html.H2;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.data.provider.DataProvider;
 import com.vaadin.flow.router.Route;
-import com.vaadin.flow.theme.NoTheme;
 
 /**
  * @author Vaadin Ltd.

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridUpdateDataProviderPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridUpdateDataProviderPage.java
@@ -31,7 +31,6 @@ import com.vaadin.flow.theme.NoTheme;
  * @author Vaadin Ltd.
  */
 @Route("grid-page")
-@NoTheme
 public class GridUpdateDataProviderPage extends Div {
 
     public static class Pojo {

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridVirtualScrollingPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridVirtualScrollingPage.java
@@ -29,7 +29,6 @@ import com.vaadin.flow.theme.NoTheme;
  * @author Vaadin Ltd.
  */
 @Route("grid-virtual-scrolling")
-@NoTheme
 public class GridVirtualScrollingPage extends Div {
 
     private DataProvider<String, ?> dataProvider = DataProvider.fromCallbacks(

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridVirtualScrollingPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridVirtualScrollingPage.java
@@ -23,7 +23,6 @@ import com.vaadin.flow.component.html.Label;
 import com.vaadin.flow.data.provider.DataProvider;
 import com.vaadin.flow.data.provider.Query;
 import com.vaadin.flow.router.Route;
-import com.vaadin.flow.theme.NoTheme;
 
 /**
  * @author Vaadin Ltd.

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridWithTemplatePage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridWithTemplatePage.java
@@ -23,7 +23,6 @@ import com.vaadin.flow.data.renderer.ComponentRenderer;
 import com.vaadin.flow.data.renderer.TemplateRenderer;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.router.Route;
-import com.vaadin.flow.theme.NoTheme;
 
 @Route("grid-template-test")
 public class GridWithTemplatePage extends Div {

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridWithTemplatePage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridWithTemplatePage.java
@@ -26,7 +26,6 @@ import com.vaadin.flow.router.Route;
 import com.vaadin.flow.theme.NoTheme;
 
 @Route("grid-template-test")
-@NoTheme
 public class GridWithTemplatePage extends Div {
 
     public GridWithTemplatePage() {

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/TextRendererPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/TextRendererPage.java
@@ -25,7 +25,6 @@ import com.vaadin.flow.router.Route;
 import com.vaadin.flow.theme.NoTheme;
 
 @Route("text-renderer")
-@NoTheme
 public class TextRendererPage extends Div {
 
     public TextRendererPage() {

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/TextRendererPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/TextRendererPage.java
@@ -22,7 +22,6 @@ import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.data.renderer.ComponentRenderer;
 import com.vaadin.flow.data.renderer.Renderer;
 import com.vaadin.flow.router.Route;
-import com.vaadin.flow.theme.NoTheme;
 
 @Route("text-renderer")
 public class TextRendererPage extends Div {

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/ToggleVisibilityPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/ToggleVisibilityPage.java
@@ -31,7 +31,6 @@ import com.vaadin.flow.theme.NoTheme;
  * @author Vaadin Ltd.
  */
 @Route("toggle-visibility")
-@NoTheme
 public class ToggleVisibilityPage extends Div {
 
     public ToggleVisibilityPage() {

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/ToggleVisibilityPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/ToggleVisibilityPage.java
@@ -22,7 +22,6 @@ import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.function.ValueProvider;
 import com.vaadin.flow.router.Route;
-import com.vaadin.flow.theme.NoTheme;
 
 /**
  * Page that reproduces the bug described at

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridChangingHierarchyPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridChangingHierarchyPage.java
@@ -29,7 +29,6 @@ import com.vaadin.flow.router.Route;
 import com.vaadin.flow.theme.NoTheme;
 
 @Route("treegrid-changing-hierarchy")
-@NoTheme
 public class TreeGridChangingHierarchyPage extends Div {
 
     private static class TestDataProvider extends TreeDataProvider<String> {

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridChangingHierarchyPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridChangingHierarchyPage.java
@@ -26,7 +26,6 @@ import com.vaadin.flow.data.provider.hierarchy.TreeDataProvider;
 import com.vaadin.flow.function.SerializablePredicate;
 import com.vaadin.flow.function.ValueProvider;
 import com.vaadin.flow.router.Route;
-import com.vaadin.flow.theme.NoTheme;
 
 @Route("treegrid-changing-hierarchy")
 public class TreeGridChangingHierarchyPage extends Div {

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridEmptyPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridEmptyPage.java
@@ -18,7 +18,6 @@ package com.vaadin.flow.component.treegrid.it;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.treegrid.TreeGrid;
 import com.vaadin.flow.router.Route;
-import com.vaadin.flow.theme.NoTheme;
 
 @Route("treegrid-empty")
 public class TreeGridEmptyPage extends Div {

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridEmptyPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridEmptyPage.java
@@ -21,7 +21,6 @@ import com.vaadin.flow.router.Route;
 import com.vaadin.flow.theme.NoTheme;
 
 @Route("treegrid-empty")
-@NoTheme
 public class TreeGridEmptyPage extends Div {
 
     public TreeGridEmptyPage() {

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridExpandAllPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridExpandAllPage.java
@@ -9,7 +9,6 @@ import com.vaadin.flow.component.treegrid.TreeGrid;
 import com.vaadin.flow.data.provider.hierarchy.TreeData;
 import com.vaadin.flow.data.provider.hierarchy.TreeDataProvider;
 import com.vaadin.flow.router.Route;
-import com.vaadin.flow.theme.NoTheme;
 
 @Route("treegrid-expand-all")
 public class TreeGridExpandAllPage extends Div {

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridExpandAllPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridExpandAllPage.java
@@ -12,7 +12,6 @@ import com.vaadin.flow.router.Route;
 import com.vaadin.flow.theme.NoTheme;
 
 @Route("treegrid-expand-all")
-@NoTheme
 public class TreeGridExpandAllPage extends Div {
 
     public TreeGridExpandAllPage() {

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridHugeTreeNavigationPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridHugeTreeNavigationPage.java
@@ -23,7 +23,6 @@ import com.vaadin.flow.component.treegrid.TreeGrid;
 import com.vaadin.flow.data.provider.hierarchy.TreeData;
 import com.vaadin.flow.data.provider.hierarchy.TreeDataProvider;
 import com.vaadin.flow.router.Route;
-import com.vaadin.flow.theme.NoTheme;
 
 import static com.vaadin.flow.component.treegrid.it.TreeGridHugeTreePage.addItems;
 import static com.vaadin.flow.component.treegrid.it.TreeGridHugeTreePage.addRootItems;

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridHugeTreeNavigationPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridHugeTreeNavigationPage.java
@@ -29,7 +29,6 @@ import static com.vaadin.flow.component.treegrid.it.TreeGridHugeTreePage.addItem
 import static com.vaadin.flow.component.treegrid.it.TreeGridHugeTreePage.addRootItems;
 
 @Route("treegrid-huge-tree-navigation")
-@NoTheme
 public class TreeGridHugeTreeNavigationPage extends Div {
 
     private TreeGrid<String> treeGrid;

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridHugeTreePage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridHugeTreePage.java
@@ -31,7 +31,6 @@ import com.vaadin.flow.router.Route;
 import com.vaadin.flow.theme.NoTheme;
 
 @Route("treegrid-huge-tree")
-@NoTheme
 public class TreeGridHugeTreePage extends Div {
 
     private TreeGrid<String> treeGrid;

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridHugeTreePage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridHugeTreePage.java
@@ -28,7 +28,6 @@ import com.vaadin.flow.component.treegrid.TreeGrid;
 import com.vaadin.flow.data.provider.hierarchy.TreeData;
 import com.vaadin.flow.data.provider.hierarchy.TreeDataProvider;
 import com.vaadin.flow.router.Route;
-import com.vaadin.flow.theme.NoTheme;
 
 @Route("treegrid-huge-tree")
 public class TreeGridHugeTreePage extends Div {

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridInitialExpandPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridInitialExpandPage.java
@@ -8,7 +8,6 @@ import com.vaadin.flow.router.Route;
 import com.vaadin.flow.theme.NoTheme;
 
 @Route("treegrid-initial-expand")
-@NoTheme
 public class TreeGridInitialExpandPage extends Div {
 
     public TreeGridInitialExpandPage() {

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridInitialExpandPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridInitialExpandPage.java
@@ -5,7 +5,6 @@ import com.vaadin.flow.component.treegrid.TreeGrid;
 import com.vaadin.flow.data.provider.hierarchy.TreeData;
 import com.vaadin.flow.data.provider.hierarchy.TreeDataProvider;
 import com.vaadin.flow.router.Route;
-import com.vaadin.flow.theme.NoTheme;
 
 @Route("treegrid-initial-expand")
 public class TreeGridInitialExpandPage extends Div {

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridItemDetailsRendererPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridItemDetailsRendererPage.java
@@ -31,7 +31,6 @@ import static com.vaadin.flow.component.treegrid.it.TreeGridHugeTreePage.addItem
 import static com.vaadin.flow.component.treegrid.it.TreeGridHugeTreePage.addRootItems;
 
 @Route("treegrid-item-details-renderer")
-@NoTheme
 public class TreeGridItemDetailsRendererPage extends Div {
 
     public TreeGridItemDetailsRendererPage() {

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridItemDetailsRendererPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridItemDetailsRendererPage.java
@@ -25,7 +25,6 @@ import com.vaadin.flow.data.provider.hierarchy.TreeData;
 import com.vaadin.flow.data.provider.hierarchy.TreeDataProvider;
 import com.vaadin.flow.data.renderer.ComponentRenderer;
 import com.vaadin.flow.router.Route;
-import com.vaadin.flow.theme.NoTheme;
 
 import static com.vaadin.flow.component.treegrid.it.TreeGridHugeTreePage.addItems;
 import static com.vaadin.flow.component.treegrid.it.TreeGridHugeTreePage.addRootItems;

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridPageSizePage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridPageSizePage.java
@@ -35,7 +35,6 @@ import static com.vaadin.flow.component.treegrid.it.TreeGridHugeTreePage.addItem
 import static com.vaadin.flow.component.treegrid.it.TreeGridHugeTreePage.addRootItems;
 
 @Route("treegrid-page-size")
-@NoTheme
 public class TreeGridPageSizePage extends Div {
 
     private TextArea log;

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridPageSizePage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridPageSizePage.java
@@ -29,7 +29,6 @@ import com.vaadin.flow.data.provider.hierarchy.TreeData;
 import com.vaadin.flow.data.provider.hierarchy.TreeDataProvider;
 import com.vaadin.flow.function.SerializablePredicate;
 import com.vaadin.flow.router.Route;
-import com.vaadin.flow.theme.NoTheme;
 
 import static com.vaadin.flow.component.treegrid.it.TreeGridHugeTreePage.addItems;
 import static com.vaadin.flow.component.treegrid.it.TreeGridHugeTreePage.addRootItems;

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridScrollingPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridScrollingPage.java
@@ -24,7 +24,6 @@ import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.theme.NoTheme;
 
 @Route("treegrid-scrolling")
-@NoTheme
 public class TreeGridScrollingPage extends Div {
 
     public static final int DEFAULT_NODES = 20;

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridScrollingPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridScrollingPage.java
@@ -21,7 +21,6 @@ import com.vaadin.flow.data.bean.HierarchicalTestBean;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinService;
-import com.vaadin.flow.theme.NoTheme;
 
 @Route("treegrid-scrolling")
 public class TreeGridScrollingPage extends Div {

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/BeanGridIT.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/BeanGridIT.java
@@ -15,11 +15,12 @@
  */
 package com.vaadin.flow.component.grid.it;
 
+import org.junit.Assert;
+import org.junit.Test;
+
 import com.vaadin.flow.component.grid.testbench.GridElement;
 import com.vaadin.flow.testutil.AbstractComponentIT;
 import com.vaadin.flow.testutil.TestPath;
-import org.junit.Assert;
-import org.junit.Test;
 
 @TestPath("beangridpage")
 public class BeanGridIT extends AbstractComponentIT {

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridDelegateFocusToComponentIT.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridDelegateFocusToComponentIT.java
@@ -16,16 +16,17 @@
 
 package com.vaadin.flow.component.grid.it;
 
-import com.vaadin.flow.component.grid.testbench.GridElement;
-import com.vaadin.flow.testutil.AbstractComponentIT;
-import com.vaadin.flow.testutil.TestPath;
-import com.vaadin.testbench.TestBenchElement;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
+
+import com.vaadin.flow.component.grid.testbench.GridElement;
+import com.vaadin.flow.testutil.AbstractComponentIT;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
 
 @TestPath("delegate-focus-inside-component-renderer")
 public class GridDelegateFocusToComponentIT extends AbstractComponentIT {

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridEditorFocusIT.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridEditorFocusIT.java
@@ -29,6 +29,13 @@
 
 package com.vaadin.flow.component.grid.it;
 
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
 import com.vaadin.flow.component.grid.testbench.GridColumnElement;
 import com.vaadin.flow.component.grid.testbench.GridElement;
 import com.vaadin.flow.component.grid.testbench.GridTHTDElement;
@@ -36,12 +43,6 @@ import com.vaadin.flow.component.grid.testbench.GridTRElement;
 import com.vaadin.flow.testutil.AbstractComponentIT;
 import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.testbench.TestBenchElement;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebElement;
 
 @TestPath("editor-focus")
 public class GridEditorFocusIT extends AbstractComponentIT {

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/HeaderTextIT.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/HeaderTextIT.java
@@ -1,12 +1,13 @@
 package com.vaadin.flow.component.grid.it;
 
-import com.vaadin.flow.component.grid.testbench.GridElement;
-import com.vaadin.flow.testutil.AbstractComponentIT;
-import com.vaadin.flow.testutil.TestPath;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.By;
+
+import com.vaadin.flow.component.grid.testbench.GridElement;
+import com.vaadin.flow.testutil.AbstractComponentIT;
+import com.vaadin.flow.testutil.TestPath;
 
 @TestPath("header-page")
 public class HeaderTextIT extends AbstractComponentIT {

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridPageSizeIT.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridPageSizeIT.java
@@ -23,7 +23,6 @@ import org.openqa.selenium.WebElement;
 
 import com.vaadin.flow.component.grid.testbench.TreeGridElement;
 import com.vaadin.flow.testutil.TestPath;
-import com.vaadin.flow.theme.NoTheme;
 
 @TestPath("treegrid-page-size")
 public class TreeGridPageSizeIT extends AbstractTreeGridIT {

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridPageSizeIT.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridPageSizeIT.java
@@ -26,7 +26,6 @@ import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.flow.theme.NoTheme;
 
 @TestPath("treegrid-page-size")
-@NoTheme
 public class TreeGridPageSizeIT extends AbstractTreeGridIT {
 
     @Before


### PR DESCRIPTION
The `@NoTheme` annotations caused build failure with `Multiple Theme configuration is not supported:`, since the integration test module contains components annotated with `@Theme(Lumo.class)`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-flow/663)
<!-- Reviewable:end -->
