### PR TITLE
Remove Lumo theme from ITs 

### DIFF
--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/BeanGridPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/BeanGridPage.java
@@ -19,11 +19,10 @@ import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.data.bean.Person;
 import com.vaadin.flow.router.Route;
-import com.vaadin.flow.theme.Theme;
-import com.vaadin.flow.theme.lumo.Lumo;
+import com.vaadin.flow.theme.NoTheme;
 
 @Route
-@Theme(Lumo.class)
+@NoTheme
 public class BeanGridPage extends Div {
 
     public BeanGridPage() {

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridTestPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridTestPage.java
@@ -29,8 +29,7 @@ import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.data.renderer.ComponentRenderer;
 import com.vaadin.flow.data.renderer.TemplateRenderer;
 import com.vaadin.flow.router.Route;
-import com.vaadin.flow.theme.Theme;
-import com.vaadin.flow.theme.lumo.Lumo;
+import com.vaadin.flow.theme.NoTheme;
 
 /**
  * Page created for testing purposes. Not suitable for demos.
@@ -39,7 +38,7 @@ import com.vaadin.flow.theme.lumo.Lumo;
  *
  */
 @Route("vaadin-grid-test")
-@Theme(Lumo.class)
+@NoTheme
 public class GridTestPage extends Div {
 
     private static class Item implements Serializable {


### PR DESCRIPTION
Multiple theme configuration is not supported in Flow. So, Lumo theme is removed from ITs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-flow/665)
<!-- Reviewable:end -->
