### PR TITLE
Fix setting initial sort order

### DIFF
--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/SortingPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/SortingPage.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2000-2019 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.it;
+
+import java.util.List;
+
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.grid.Grid.Column;
+import com.vaadin.flow.component.grid.GridSortOrder;
+import com.vaadin.flow.component.grid.GridSortOrderBuilder;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.data.bean.Person;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.theme.Theme;
+import com.vaadin.flow.theme.lumo.Lumo;
+
+@Route("sorting")
+@Theme(Lumo.class)
+public class SortingPage extends Div {
+
+    public SortingPage() {
+        Grid<Person> grid = new Grid<>();
+        grid.setItems(new Person("B", 20), new Person("A", 30));
+        Column<Person> nameColumn = grid.addColumn(Person::getFirstName)
+                .setHeader("Name");
+        Column<Person> ageColumn = grid.addColumn(Person::getAge)
+                .setHeader("Age");
+        add(grid);
+
+        List<GridSortOrder<Person>> sortByName = new GridSortOrderBuilder<Person>()
+                .thenAsc(nameColumn).build();
+        grid.sort(sortByName);
+
+        NativeButton button = new NativeButton("Sort by age", e -> {
+            List<GridSortOrder<Person>> sortByAge = new GridSortOrderBuilder<Person>()
+                    .thenAsc(ageColumn).build();
+            grid.sort(sortByAge);
+        });
+        button.setId("sort-by-age");
+        add(button);
+    }
+
+}

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/SortingIT.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/SortingIT.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2000-2019 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.it;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import com.vaadin.flow.component.grid.testbench.GridElement;
+import com.vaadin.flow.testutil.AbstractComponentIT;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+
+@TestPath("sorting")
+public class SortingIT extends AbstractComponentIT {
+
+    private GridElement grid;
+
+    @Before
+    public void init() {
+        open();
+        grid = $(GridElement.class).first();
+    }
+
+    @Test
+    public void setInitialSortOrder_dataSorted() {
+        Assert.assertEquals("A", grid.getCell(0, 0).getText());
+        Assert.assertEquals("B", grid.getCell(1, 0).getText());
+    }
+
+    @Test
+    public void setInitialSortOrder_sortIndicatorsUpdated() {
+        assertAscendingSorter("Name");
+    }
+
+    @Test
+    public void setInitialSortOrder_changeOrderFromServer_dataSorted() {
+        findElement(By.id("sort-by-age")).click();
+        Assert.assertEquals("B", grid.getCell(0, 0).getText());
+        Assert.assertEquals("A", grid.getCell(1, 0).getText());
+    }
+
+    @Test
+    public void setInitialSortOrder_changeOrderFromServer_sortIndicatorsUpdated() {
+        findElement(By.id("sort-by-age")).click();
+        assertAscendingSorter("Age");
+    }
+
+    private void assertAscendingSorter(String expectedColumnHeader) {
+        List<TestBenchElement> sorters = grid.$("vaadin-grid-sorter")
+                .hasAttribute("direction").all();
+        Assert.assertEquals("Only one column should be sorted. "
+                + "Expected a single instance of <vaadin-grid-sorter> with 'direction' attribute.",
+                1, sorters.size());
+        TestBenchElement sorter = sorters.get(0);
+        Assert.assertEquals("Expected ascending sort order.", "asc",
+                sorter.getAttribute("direction"));
+        Assert.assertEquals(expectedColumnHeader, sorter.getText());
+    }
+
+}

--- a/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -401,8 +401,8 @@ window.Vaadin.Flow.gridConnector = {
       }
     }
 
-    const sorterChangeListener = function() {
-      if (!sorterDirectionsSetFromServer) {
+    const sorterChangeListener = function(_, oldValue) {
+      if (oldValue !== undefined && !sorterDirectionsSetFromServer) {
         grid.$server.sortersChanged(grid._sorters.map(function(sorter) {
           return {
             path: sorter.path,
@@ -413,22 +413,23 @@ window.Vaadin.Flow.gridConnector = {
     }
 
     grid.$connector.setSorterDirections = function(directions) {
-      try {
-        sorterDirectionsSetFromServer = true;
+      sorterDirectionsSetFromServer = true;
+      setTimeout(() => {
+        try {
+          let allSorters = grid.querySelectorAll("vaadin-grid-sorter");
+          allSorters.forEach(sorter => sorter.direction = null);
 
-        let allSorters = grid.querySelectorAll("vaadin-grid-sorter");
-        allSorters.forEach(sorter => sorter.direction = null);
-
-        for (let i = directions.length - 1; i >= 0; i--) {
-          const columnId = directions[i].column;
-          let sorter = grid.querySelector("vaadin-grid-sorter[path='" + columnId + "']");
-          if (sorter) {
-            sorter.direction = directions[i].direction;
+          for (let i = directions.length - 1; i >= 0; i--) {
+            const columnId = directions[i].column;
+            let sorter = grid.querySelector("vaadin-grid-sorter[path='" + columnId + "']");
+            if (sorter) {
+              sorter.direction = directions[i].direction;
+            }
           }
+        } finally {
+          sorterDirectionsSetFromServer = false;
         }
-      } finally {
-        sorterDirectionsSetFromServer = false;
-      }
+      });
     }
     grid._createPropertyObserver("_previousSorters", sorterChangeListener);
 


### PR DESCRIPTION
Updating the client-side sorters needed to be postponed, because the
sorter elements were not present at the time of this JS execution when
done on the same roundtrip as creating/attaching the grid. The grid
would finalize its initialization afterwards with empty sort orders,
causing un-sorted data to be requested from the server.

Also, the initial call to the sorter observer needed to be disabled so
it doesn't reset the sort order.

Fix #13
Fix #465 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-flow/672)
<!-- Reviewable:end -->
