### PR TITLE
Disable the w3c communication mode for remote tests.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,8 +56,8 @@
                 </property>
             </activation>
             <modules>
-                <module>vaadin-grid-flow-integration-tests</module>
                 <module>vaadin-grid-flow-integration-tests/pom-bower-mode.xml</module>
+                <module>vaadin-grid-flow-integration-tests</module>
             </modules>
         </profile>
     </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -56,8 +56,8 @@
                 </property>
             </activation>
             <modules>
-                <module>vaadin-grid-flow-integration-tests/pom-bower-mode.xml</module>
                 <module>vaadin-grid-flow-integration-tests</module>
+                <module>vaadin-grid-flow-integration-tests/pom-bower-mode.xml</module>
             </modules>
         </profile>
     </profiles>

--- a/vaadin-grid-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-grid-flow-integration-tests/pom-bower-mode.xml
@@ -129,6 +129,7 @@
                 <artifactId>flow-maven-plugin</artifactId>
                 <configuration>
                     <bowerMode>true</bowerMode>
+                    <productionMode>false</productionMode>
                 </configuration>
             </plugin>
             <!-- start jetty before ITs -->

--- a/vaadin-grid-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-grid-flow-integration-tests/pom-bower-mode.xml
@@ -125,25 +125,11 @@
         <plugins>
             <!-- Activate BOWER MODE -->
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>properties-maven-plugin</artifactId>
-                <version>1.0.0</version>
-                <executions>
-                    <execution>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>set-system-properties</goal>
-                        </goals>
-                        <configuration>
-                            <properties>
-                                <property>
-                                    <name>vaadin.bowerMode</name>
-                                    <value>true</value>
-                                </property>
-                            </properties>
-                        </configuration>
-                    </execution>
-                </executions>
+                <groupId>com.vaadin</groupId>
+                <artifactId>flow-maven-plugin</artifactId>
+                <configuration>
+                    <bowerMode>true</bowerMode>
+                </configuration>
             </plugin>
             <!-- start jetty before ITs -->
             <plugin>

--- a/vaadin-grid-flow-integration-tests/pom.xml
+++ b/vaadin-grid-flow-integration-tests/pom.xml
@@ -118,13 +118,14 @@
 
     <build>
         <plugins>
-            <!-- run tests against production bundle in orther to save system
+            <!-- run tests against production bundle in order to save system
                  resources as webpack-dev-server is not running in bg -->
             <!-- run vaadin frontend verify and build goals -->
             <plugin>
                 <groupId>com.vaadin</groupId>
                 <artifactId>flow-maven-plugin</artifactId>
                 <configuration>
+                    <bowerMode>false</bowerMode>
                     <productionMode>true</productionMode>
                 </configuration>
             </plugin>

--- a/vaadin-grid-flow-integration-tests/pom.xml
+++ b/vaadin-grid-flow-integration-tests/pom.xml
@@ -120,31 +120,13 @@
         <plugins>
             <!-- run tests against production bundle in orther to save system
                  resources as webpack-dev-server is not running in bg -->
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>properties-maven-plugin</artifactId>
-                <version>1.0.0</version>
-                <executions>
-                    <execution>
-                        <phase>ititialize</phase>
-                        <goals>
-                            <goal>set-system-properties</goal>
-                        </goals>
-                        <configuration>
-                            <properties>
-                                <property>
-                                    <name>vaadin.productionMode</name>
-                                    <value>true</value>
-                                </property>
-                            </properties>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
             <!-- run vaadin frontend verify and build goals -->
             <plugin>
                 <groupId>com.vaadin</groupId>
                 <artifactId>flow-maven-plugin</artifactId>
+                <configuration>
+                    <productionMode>true</productionMode>
+                </configuration>
             </plugin>
             <!-- start jetty before ITs -->
             <plugin>

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/AbstractNoW3c.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/AbstractNoW3c.java
@@ -33,7 +33,7 @@ public class AbstractNoW3c extends AbstractComponentIT {
 
     @Override
     public void setup() throws Exception {
-        if (Browser.CHROME == this.getRunLocallyBrowser() && (
+        if (getDesiredCapabilities().getBrowserName().equals(Browser.CHROME.name()) &&(
                 getRunOnHub(getClass()) != null
                         || Parameters.getHubHostname() != null)) {
 

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/AbstractNoW3c.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/AbstractNoW3c.java
@@ -24,7 +24,6 @@ import org.openqa.selenium.remote.RemoteWebDriver;
 import com.vaadin.flow.testutil.AbstractComponentIT;
 import com.vaadin.testbench.Parameters;
 import com.vaadin.testbench.TestBench;
-import com.vaadin.testbench.parallel.Browser;
 
 /**
  * Temp class for disabling the w3c communication mode on remote chrome.
@@ -33,9 +32,8 @@ public class AbstractNoW3c extends AbstractComponentIT {
 
     @Override
     public void setup() throws Exception {
-        if (getDesiredCapabilities().getBrowserName().equals(Browser.CHROME.name()) &&(
-                getRunOnHub(getClass()) != null
-                        || Parameters.getHubHostname() != null)) {
+        if (getRunOnHub(getClass()) != null
+                        || Parameters.getHubHostname() != null) {
 
             ChromeOptions options = new ChromeOptions();
             options.addArguments(

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/AbstractNoW3c.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/AbstractNoW3c.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component;
+
+import java.net.URL;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import com.vaadin.flow.testutil.AbstractComponentIT;
+import com.vaadin.testbench.Parameters;
+import com.vaadin.testbench.TestBench;
+import com.vaadin.testbench.parallel.Browser;
+
+/**
+ * Temp class for disabling the w3c communication mode on remote chrome.
+ */
+public class AbstractNoW3c extends AbstractComponentIT {
+
+    @Override
+    public void setup() throws Exception {
+        if (Browser.CHROME == this.getRunLocallyBrowser() && (
+                getRunOnHub(getClass()) != null
+                        || Parameters.getHubHostname() != null)) {
+
+            ChromeOptions options = new ChromeOptions();
+            options.addArguments(
+                    new String[] { "--headless", "--disable-gpu" });
+            options.setExperimentalOption("w3c", false);
+
+            options.merge(getDesiredCapabilities());
+            setDesiredCapabilities(getDesiredCapabilities());
+
+            WebDriver driver = TestBench.createDriver(
+                    new RemoteWebDriver(new URL(getHubURL()), options));
+            setDriver(driver);
+        } else {
+            super.setup();
+        }
+    }
+}

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/contextmenu/ContextMenuGridIT.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/contextmenu/ContextMenuGridIT.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.grid.contextmenu;
 
+import java.net.URL;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
@@ -23,11 +24,16 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.remote.RemoteWebDriver;
 
 import com.vaadin.flow.component.grid.testbench.GridElement;
 import com.vaadin.flow.testutil.AbstractComponentIT;
 import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.Parameters;
+import com.vaadin.testbench.TestBench;
 import com.vaadin.testbench.TestBenchElement;
 
 @TestPath("context-menu-grid")
@@ -44,6 +50,27 @@ public class ContextMenuGridIT extends AbstractComponentIT {
         verifyClosed();
     }
 
+
+    @Override
+    public void setup() throws Exception {
+        if (getRunOnHub(getClass()) != null
+                || Parameters.getHubHostname() != null) {
+
+            ChromeOptions options = new ChromeOptions();
+            options.addArguments(new String[]{"--headless", "--disable-gpu"});
+            options.setExperimentalOption("w3c", false);
+
+            options.merge(getDesiredCapabilities());
+            setDesiredCapabilities(getDesiredCapabilities());
+
+            WebDriver driver =  TestBench.createDriver(
+                    new RemoteWebDriver(new URL(getHubURL()), options));
+            setDriver(driver);
+        } else {
+            super.setup();
+        }
+    }
+    
     @Test
     public void contextClickOnRow_itemClickGetsTargetItem() {
         grid.getCell(56, 1).contextClick();

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/contextmenu/ContextMenuGridIT.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/contextmenu/ContextMenuGridIT.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.flow.component.grid.contextmenu;
 
-import java.net.URL;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
@@ -24,20 +23,15 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.chrome.ChromeOptions;
-import org.openqa.selenium.remote.RemoteWebDriver;
 
+import com.vaadin.flow.component.AbstractNoW3c;
 import com.vaadin.flow.component.grid.testbench.GridElement;
-import com.vaadin.flow.testutil.AbstractComponentIT;
 import com.vaadin.flow.testutil.TestPath;
-import com.vaadin.testbench.Parameters;
-import com.vaadin.testbench.TestBench;
 import com.vaadin.testbench.TestBenchElement;
 
 @TestPath("context-menu-grid")
-public class ContextMenuGridIT extends AbstractComponentIT {
+public class ContextMenuGridIT extends AbstractNoW3c {
 
     private static final String OVERLAY_TAG = "vaadin-context-menu-overlay";
 
@@ -51,26 +45,7 @@ public class ContextMenuGridIT extends AbstractComponentIT {
     }
 
 
-    @Override
-    public void setup() throws Exception {
-        if (getRunOnHub(getClass()) != null
-                || Parameters.getHubHostname() != null) {
 
-            ChromeOptions options = new ChromeOptions();
-            options.addArguments(new String[]{"--headless", "--disable-gpu"});
-            options.setExperimentalOption("w3c", false);
-
-            options.merge(getDesiredCapabilities());
-            setDesiredCapabilities(getDesiredCapabilities());
-
-            WebDriver driver =  TestBench.createDriver(
-                    new RemoteWebDriver(new URL(getHubURL()), options));
-            setDriver(driver);
-        } else {
-            super.setup();
-        }
-    }
-    
     @Test
     public void contextClickOnRow_itemClickGetsTargetItem() {
         grid.getCell(56, 1).contextClick();

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/DynamicEditorKBNavigationIT.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/DynamicEditorKBNavigationIT.java
@@ -15,12 +15,17 @@
  */
 package com.vaadin.flow.component.grid.it;
 
+import java.net.URL;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
+import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.interactions.Actions;
+import org.openqa.selenium.remote.RemoteWebDriver;
 
 import com.vaadin.flow.component.grid.testbench.GridColumnElement;
 import com.vaadin.flow.component.grid.testbench.GridElement;
@@ -28,10 +33,32 @@ import com.vaadin.flow.component.grid.testbench.GridTHTDElement;
 import com.vaadin.flow.component.grid.testbench.GridTRElement;
 import com.vaadin.flow.testutil.AbstractComponentIT;
 import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.Parameters;
+import com.vaadin.testbench.TestBench;
 import com.vaadin.testbench.TestBenchElement;
 
 @TestPath("dynamic-editor-keyboard")
 public class DynamicEditorKBNavigationIT extends AbstractComponentIT {
+
+    @Override
+    public void setup() throws Exception {
+        if (getRunOnHub(getClass()) != null
+                || Parameters.getHubHostname() != null) {
+
+            ChromeOptions options = new ChromeOptions();
+            options.addArguments(new String[]{"--headless", "--disable-gpu"});
+            options.setExperimentalOption("w3c", false);
+
+            options.merge(getDesiredCapabilities());
+            setDesiredCapabilities(getDesiredCapabilities());
+
+            WebDriver driver =  TestBench.createDriver(
+                    new RemoteWebDriver(new URL(getHubURL()), options));
+            setDriver(driver);
+        } else {
+            super.setup();
+        }
+    }
 
     @Test
     public void navigateBetweenEditorsUsingKeybaord() {

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/DynamicEditorKBNavigationIT.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/DynamicEditorKBNavigationIT.java
@@ -15,50 +15,23 @@
  */
 package com.vaadin.flow.component.grid.it;
 
-import java.net.URL;
-
 import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
-import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.interactions.Actions;
-import org.openqa.selenium.remote.RemoteWebDriver;
 
+import com.vaadin.flow.component.AbstractNoW3c;
 import com.vaadin.flow.component.grid.testbench.GridColumnElement;
 import com.vaadin.flow.component.grid.testbench.GridElement;
 import com.vaadin.flow.component.grid.testbench.GridTHTDElement;
 import com.vaadin.flow.component.grid.testbench.GridTRElement;
-import com.vaadin.flow.testutil.AbstractComponentIT;
 import com.vaadin.flow.testutil.TestPath;
-import com.vaadin.testbench.Parameters;
-import com.vaadin.testbench.TestBench;
 import com.vaadin.testbench.TestBenchElement;
 
 @TestPath("dynamic-editor-keyboard")
-public class DynamicEditorKBNavigationIT extends AbstractComponentIT {
-
-    @Override
-    public void setup() throws Exception {
-        if (getRunOnHub(getClass()) != null
-                || Parameters.getHubHostname() != null) {
-
-            ChromeOptions options = new ChromeOptions();
-            options.addArguments(new String[]{"--headless", "--disable-gpu"});
-            options.setExperimentalOption("w3c", false);
-
-            options.merge(getDesiredCapabilities());
-            setDesiredCapabilities(getDesiredCapabilities());
-
-            WebDriver driver =  TestBench.createDriver(
-                    new RemoteWebDriver(new URL(getHubURL()), options));
-            setDriver(driver);
-        } else {
-            super.setup();
-        }
-    }
+public class DynamicEditorKBNavigationIT extends AbstractNoW3c {
 
     @Test
     public void navigateBetweenEditorsUsingKeybaord() {

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewIT.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewIT.java
@@ -47,7 +47,6 @@ import com.vaadin.flow.demo.TabbedComponentDemoTest;
 import com.vaadin.testbench.Parameters;
 import com.vaadin.testbench.TestBench;
 import com.vaadin.testbench.TestBenchElement;
-import com.vaadin.testbench.parallel.Browser;
 
 /**
  * Integration tests for the {@link GridView}.
@@ -58,9 +57,8 @@ public class GridViewIT extends TabbedComponentDemoTest {
 
     @Override
     public void setup() throws Exception {
-        if (Browser.CHROME == this.getRunLocallyBrowser() && (
-                getRunOnHub(getClass()) != null
-                        || Parameters.getHubHostname() != null)) {
+        if (getRunOnHub(getClass()) != null
+                || Parameters.getHubHostname() != null) {
 
             ChromeOptions options = new ChromeOptions();
             options.addArguments(

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewIT.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewIT.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.grid.it;
 
+import java.net.URL;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -30,8 +31,11 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
+import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.interactions.Actions;
+import org.openqa.selenium.remote.RemoteWebDriver;
 
 import com.vaadin.flow.component.grid.ColumnTextAlign;
 import com.vaadin.flow.component.grid.testbench.GridColumnElement;
@@ -40,7 +44,10 @@ import com.vaadin.flow.component.grid.testbench.GridTHTDElement;
 import com.vaadin.flow.component.grid.testbench.GridTRElement;
 import com.vaadin.flow.data.provider.QuerySortOrder;
 import com.vaadin.flow.demo.TabbedComponentDemoTest;
+import com.vaadin.testbench.Parameters;
+import com.vaadin.testbench.TestBench;
 import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.parallel.Browser;
 
 /**
  * Integration tests for the {@link GridView}.
@@ -48,6 +55,28 @@ import com.vaadin.testbench.TestBenchElement;
 public class GridViewIT extends TabbedComponentDemoTest {
 
     private static final String OVERLAY_TAG = "vaadin-context-menu-overlay";
+
+    @Override
+    public void setup() throws Exception {
+        if (Browser.CHROME == this.getRunLocallyBrowser() && (
+                getRunOnHub(getClass()) != null
+                        || Parameters.getHubHostname() != null)) {
+
+            ChromeOptions options = new ChromeOptions();
+            options.addArguments(
+                    new String[] { "--headless", "--disable-gpu" });
+            options.setExperimentalOption("w3c", false);
+
+            options.merge(getDesiredCapabilities());
+            setDesiredCapabilities(getDesiredCapabilities());
+
+            WebDriver driver = TestBench.createDriver(
+                    new RemoteWebDriver(new URL(getHubURL()), options));
+            setDriver(driver);
+        } else {
+            super.setup();
+        }
+    }
 
     @Test
     public void dataIsShown() throws InterruptedException {

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/HiddenColumnIT.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/HiddenColumnIT.java
@@ -22,12 +22,13 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
 
+import com.vaadin.flow.component.AbstractNoW3c;
 import com.vaadin.flow.component.grid.testbench.GridElement;
 import com.vaadin.flow.testutil.AbstractComponentIT;
 import com.vaadin.flow.testutil.TestPath;
 
 @TestPath("hidden-column")
-public class HiddenColumnIT extends AbstractComponentIT {
+public class HiddenColumnIT extends AbstractNoW3c {
 
     private GridElement grid;
 

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/ItemClickListenerIT.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/ItemClickListenerIT.java
@@ -22,13 +22,14 @@ import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
+import com.vaadin.flow.component.AbstractNoW3c;
 import com.vaadin.flow.component.grid.testbench.GridElement;
 import com.vaadin.flow.component.grid.testbench.GridTRElement;
 import com.vaadin.flow.testutil.AbstractComponentIT;
 import com.vaadin.flow.testutil.TestPath;
 
 @TestPath("item-click-listener")
-public class ItemClickListenerIT extends AbstractComponentIT {
+public class ItemClickListenerIT extends AbstractNoW3c {
 
     @Test
     public void doubleClickGoesWithSingleClicks() throws InterruptedException {

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/UpdateEditorComponentIT.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/UpdateEditorComponentIT.java
@@ -19,6 +19,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.By;
 
+import com.vaadin.flow.component.AbstractNoW3c;
 import com.vaadin.flow.component.grid.testbench.GridColumnElement;
 import com.vaadin.flow.component.grid.testbench.GridElement;
 import com.vaadin.flow.component.grid.testbench.GridTHTDElement;
@@ -28,7 +29,7 @@ import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.testbench.TestBenchElement;
 
 @TestPath("update-editor")
-public class UpdateEditorComponentIT extends AbstractComponentIT {
+public class UpdateEditorComponentIT extends AbstractNoW3c {
 
     @Test
     public void updateEditorComponent() {

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/AbstractTreeGridIT.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/AbstractTreeGridIT.java
@@ -4,11 +4,12 @@ import org.junit.Assert;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
+import com.vaadin.flow.component.AbstractNoW3c;
 import com.vaadin.flow.component.grid.testbench.GridColumnElement;
 import com.vaadin.flow.component.grid.testbench.TreeGridElement;
 import com.vaadin.flow.testutil.AbstractComponentIT;
 
-public abstract class AbstractTreeGridIT extends AbstractComponentIT {
+public abstract class AbstractTreeGridIT extends AbstractNoW3c {
 
     private TreeGridElement grid;
 


### PR DESCRIPTION
To fix grid tests we should get w3c communication mode disabled
for the chrome browser.

Fixes #673 

Needs new ticket for disabling functionality the w3c compatibility is fixed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-flow/674)
<!-- Reviewable:end -->
