### PR TITLE
Also set beanType in protected Grid constructor

### DIFF
--- a/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -1247,6 +1247,7 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
         Objects.requireNonNull(beanType, "Bean type can't be null");
         Objects.requireNonNull(dataCommunicatorBuilder,
                 "Data communicator builder can't be null");
+        this.beanType = beanType;
         propertySet = BeanPropertySet.get(beanType);
         propertySet.getProperties()
                 .filter(property -> !property.isSubProperty())


### PR DESCRIPTION
In the pull request #556 I forgot to set the beanType in the protected Grid Constructor. This commit also adds it there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-flow/681)
<!-- Reviewable:end -->
