### PR TITLE
Replace $connector.columnToIdMap with properties

### DIFF
--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridStylingPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridStylingPage.java
@@ -80,12 +80,23 @@ public class GridStylingPage extends Div {
                 });
         secondColumnClassNameGenerator.setId("second-column-generator");
 
+        NativeButton toggleAttached = new NativeButton("detach/attach grid",
+                e -> {
+                    if (grid.getParent().isPresent()) {
+                        remove(grid);
+                    } else {
+                        add(grid);
+                    }
+                });
+        toggleAttached.setId("toggle-attached");
+
         add(grid,
                 new Div(gridClassNameGenerator, columnClassNameGenerator,
                         secondColumnClassNameGenerator),
                 new Div(resetGridClassNameGenerator,
                         resetColumnClassNameGenerator),
-                new Div(gridMultipleClasses, columnMultipleClasses));
+                new Div(gridMultipleClasses, columnMultipleClasses),
+                new Div(toggleAttached));
     }
 
 }

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridStylingIT.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridStylingIT.java
@@ -141,6 +141,21 @@ public class GridStylingIT extends AbstractComponentIT {
                 "grid foo col bar", "grid foo");
     }
 
+    @Test
+    public void setGridAndColumnClassNameGenerators_detach_attach_classesEffective() {
+        click("grid-generator");
+        click("column-generator");
+
+        click("toggle-attached");
+        click("toggle-attached");
+        grid = $(GridElement.class).first();
+
+        assertCellClassNames( //
+                "grid0 col0", "grid0", //
+                "grid1 col1", "grid1", //
+                "grid2 col2", "grid2");
+    }
+
     /**
      * Compares each class to the cell at the corresponding index
      */

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridTestPageIT.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridTestPageIT.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.flow.component.grid.it;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -30,10 +29,8 @@ import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
-import com.vaadin.flow.component.grid.testbench.GridElement;
 import com.vaadin.flow.testutil.AbstractComponentIT;
 import com.vaadin.flow.testutil.TestPath;
-import com.vaadin.testbench.TestBenchElement;
 
 /**
  * 
@@ -198,26 +195,6 @@ public class GridTestPageIT extends AbstractComponentIT {
             Assert.assertEquals(String.valueOf(row),
                     String.valueOf(map.get("col2")));
         });
-    }
-
-    @Test
-    public void removeColumn_removedFromClientDataStructure() {
-        GridElement grid = $(GridElement.class)
-                .id("grid-with-removable-columns");
-        assertClientColumnIds(new String[] { "col1", "col2" }, grid);
-
-        $(TestBenchElement.class).id("remove-name-column-button").click();
-        assertClientColumnIds(new String[] { "col2" }, grid);
-    }
-
-    @SuppressWarnings("unchecked")
-    private void assertClientColumnIds(String[] expectedIds, GridElement grid) {
-        List<String> columnIds = (List<String>) executeScript(
-                "return Array.from(arguments[0].$connector.columnToIdMap.values())",
-                grid);
-        Assert.assertArrayEquals(
-                "The client connector contains unexpected column ids",
-                expectedIds, columnIds.toArray(new String[columnIds.size()]));
     }
 
     @Test

--- a/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -1584,8 +1584,7 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
 
         C column = columnFactory.apply(renderer, columnId);
         idToColumnMap.put(columnId, column);
-        getElement().callJsFunction("$connector.setColumnId",
-                column.getElement(), columnId);
+        column.getElement().setProperty("_flowId", columnId);
 
         AbstractColumn<?> current = column;
         columnLayers.get(0).addColumn(column);
@@ -2681,8 +2680,6 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
         column.destroyDataGenerators();
         keyToColumnMap.remove(column.getKey());
         idToColumnMap.remove(column.getInternalId());
-        getElement().callJsFunction("$connector.columnRemoved",
-                column.getInternalId());
     }
 
     /**

--- a/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -971,29 +971,12 @@ window.Vaadin.Flow.gridConnector = {
         grid.$connector.clickedItem = null;
     }
 
-    grid.$connector.columnToIdMap = new Map();
-    grid.$connector.setColumnId = function(column, id) {
-        grid.$connector.columnToIdMap.set(column, id);
-    }
-
-    grid.$connector.columnRemoved = function(columnId) {
-        const entries = Array.from(grid.$connector.columnToIdMap);
-        const entryToRemove = entries.filter(function(entry) {
-            return entry[1] === columnId;
-        })[0];
-        if (entryToRemove) {
-            grid.$connector.columnToIdMap.delete(entryToRemove[0]);
-        }
-    }
-
     grid.cellClassNameGenerator = function(column, rowData) {
         const style = rowData.item.style;
         if (!style) {
             return;
         }
-        const columnId = grid.$connector.columnToIdMap.get(column);
-
-        return (style.row || '') + ' ' + (style[columnId] || '');
+        return (style.row || '') + ' ' + (style[column._flowId] || '');
     }
 
     grid.dropFilter = rowData => !rowData.item.dropDisabled;


### PR DESCRIPTION
Using the map already needed a lot of code to keep it up to date, and in
order to solve #684, more logic would've been needed to maintain it also
when grid/columns are re-attached to the DOM. Saving the column ids as
properties makes Flow take care of this automatically.

Fix #684

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-flow/695)
<!-- Reviewable:end -->
