### PR TITLE
DetailsRenderer and ClassNameGenerator in the same Grid fails

### DIFF
--- a/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -922,10 +922,10 @@ window.Vaadin.Flow.gridConnector = {
 
     grid.cellClassNameGenerator = function(column, rowData) {
         const style = rowData.item.style;
-        if (!style ||!column) {
+        if (!style) {
             return;
         }
-        return (style.row || '') + ' ' + (style[column._flowId] || '');
+        return (style.row || '') + ' ' + ((column && style[column._flowId]) || '');
     }
 
     grid.dropFilter = rowData => !rowData.item.dropDisabled;

--- a/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -922,7 +922,7 @@ window.Vaadin.Flow.gridConnector = {
 
     grid.cellClassNameGenerator = function(column, rowData) {
         const style = rowData.item.style;
-        if (!style) {
+        if (!style ||!column) {
             return;
         }
         return (style.row || '') + ' ' + (style[column._flowId] || '');


### PR DESCRIPTION
If I have a column with a ClassNameGenerator in a Grid where I also have a DetailsRenderer,
The code accesses the ClassNameGenerator-method with an undefined column. This is a solution to that problem.
It might be a bandaid on another problem, but it at least solves it.
(This is my first pull-request ever, tell me if I do something wrong)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-flow/717)
<!-- Reviewable:end -->
