### PR TITLE
Multiselect perf: send updates only to loaded items

### DIFF
--- a/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -2494,6 +2494,10 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
         callSelectionFunctionForItems("doDeselection", items);
     }
 
+    boolean isInActiveRange(T item) {
+        return getDataCommunicator().getKeyMapper().has(item);
+    }
+
     private void callSelectionFunctionForItems(String function, Set<T> items) {
         if (items.isEmpty()) {
             return;


### PR DESCRIPTION
Part of the multiselection performance improvements #451.

This decreases both the space complexity of the update message sent from server to client, as well as the time complexity of the client-side execution, from linear _O(N)_ to constant _O(1)_, where _N_ is number of items to select/deselect (when _N_ is larger than the number of items present at client-side).

This doesn't affect the server-side performance, which still operates on the full data set on `selectAll`.

Testing the performance of  `selectAll` before the fix (still including the previous perfo fix in #715) and after, with 1,000 items and 10,000 `String` items:

|                                     | Before  | After |
|-------------------------------------|---------:|-------:|
| 1k items: time from click to paint including server roundtrip  |   440ms | 210ms |
| 10k items: time from click to paint including server roundtrip | 6,650ms | 260ms |
| 1k items: $connector JS execution   |   280ms |  80ms |
| 10k items: $connector JS execution  | 1,570ms |  80ms |

With 10k items, most of the  time was actually spent somewhere outside of the Grid code to transfer the huge update message (Chrome dev tools said 1,3MB), as the JS code took only a small part of the time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-flow/723)
<!-- Reviewable:end -->
