### PR TITLE
Treegrid details is not working after collapse then expand a node

### DIFF
--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridDetailsRowPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridDetailsRowPage.java
@@ -3,24 +3,13 @@ package com.vaadin.flow.component.grid.it;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.data.bean.Person;
-import com.vaadin.flow.data.provider.CallbackDataProvider;
-import com.vaadin.flow.data.provider.ConfigurableFilterDataProvider;
-import com.vaadin.flow.data.provider.DataProvider;
 import com.vaadin.flow.data.provider.ListDataProvider;
 import com.vaadin.flow.data.renderer.ComponentRenderer;
 import com.vaadin.flow.router.Route;
 
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @Route("grid-details-row")
 public class GridDetailsRowPage extends Div {
@@ -32,10 +21,6 @@ public class GridDetailsRowPage extends Div {
     private Person person3 = new Person("Person 3", 2);
     private Person person4 = new Person("Person 4", 1111);
 
-    public void setFirstAndSecondItemsVisible() {
-        grid.setDetailsVisible(items.get(0), true);
-        grid.setDetailsVisible(items.get(1), true);
-    }
     public GridDetailsRowPage() {
 
         items.add(new Person("Person 1", 99));
@@ -46,14 +31,13 @@ public class GridDetailsRowPage extends Div {
         ListDataProvider<Person> ldp = new ListDataProvider<>(items);
         grid.setDataProvider(ldp);
 
-        Grid.Column<Person> nameColumn = grid.addColumn(bean -> bean.getFirstName()).setHeader("name");
+        grid.addColumn(Person::getFirstName).setHeader("name");
         grid.setItemDetailsRenderer(new ComponentRenderer<>(item -> new Button(item.getFirstName())));
-        // grid.setDetailsVisibleOnClick(false);
 
         add(grid,
-                new Button("click to open details", e -> {
-                    setFirstAndSecondItemsVisible(); // same method call as above
-                })
+                new Button("click to open details", e ->
+                    setFirstAndSecondItemsVisible()
+                )
         );
         Button updatePerson3 = new Button("update and refresh person 3", e -> {
             nbUpdates++;
@@ -72,4 +56,8 @@ public class GridDetailsRowPage extends Div {
         setFirstAndSecondItemsVisible();
     }
 
+    public void setFirstAndSecondItemsVisible() {
+        grid.setDetailsVisible(items.get(0), true);
+        grid.setDetailsVisible(items.get(1), true);
+    }
 }

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridDetailsRowPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridDetailsRowPage.java
@@ -43,15 +43,15 @@ public class GridDetailsRowPage extends Div {
 
         Grid.Column<Person> nameColumn = grid.addColumn(bean -> bean.getFirstName()).setHeader("name");
         grid.setItemDetailsRenderer(new ComponentRenderer<>(item -> new Button(item.getFirstName())));
-        grid.setDetailsVisibleOnClick(false);
+        // grid.setDetailsVisibleOnClick(false);
+
         add(grid,
                 new Button("click to open details", e -> {
                     setFirstAndSecondItemsVisible(); // same method call as above
                 })
         );
-        grid.getElement().getNode()
-                .runWhenAttached(ui -> ui.getInternals().getStateTree()
-                        .beforeClientResponse(grid.getElement().getNode(), e -> setFirstAndSecondItemsVisible()));
+
+        setFirstAndSecondItemsVisible();
     }
 
 }

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridDetailsRowPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridDetailsRowPage.java
@@ -1,0 +1,57 @@
+package com.vaadin.flow.component.grid.it;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.textfield.TextField;
+import com.vaadin.flow.data.bean.Person;
+import com.vaadin.flow.data.provider.CallbackDataProvider;
+import com.vaadin.flow.data.provider.ConfigurableFilterDataProvider;
+import com.vaadin.flow.data.provider.DataProvider;
+import com.vaadin.flow.data.provider.ListDataProvider;
+import com.vaadin.flow.data.renderer.ComponentRenderer;
+import com.vaadin.flow.router.Route;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Route("grid-details-row")
+public class GridDetailsRowPage extends Div {
+
+    private Grid<Person> grid = new Grid<>();
+    private List<Person> items = new ArrayList<>();
+
+    public void setFirstAndSecondItemsVisible() {
+        grid.setDetailsVisible(items.get(0), true);
+        grid.setDetailsVisible(items.get(1), true);
+    }
+    public GridDetailsRowPage() {
+        items.add(new Person("Person 1", 99));
+        items.add(new Person("Person 2", 1));
+        items.add(new Person("Person 3", 2));
+        items.add(new Person("Person 4", 1111));
+
+        ListDataProvider<Person> ldp = new ListDataProvider<>(items);
+        grid.setDataProvider(ldp);
+
+        Grid.Column<Person> nameColumn = grid.addColumn(bean -> bean.getFirstName()).setHeader("name");
+        grid.setItemDetailsRenderer(new ComponentRenderer<>(item -> new Button(item.getFirstName())));
+        grid.setDetailsVisibleOnClick(false);
+        add(grid,
+                new Button("click to open details", e -> {
+                    setFirstAndSecondItemsVisible(); // same method call as above
+                })
+        );
+        grid.getElement().getNode()
+                .runWhenAttached(ui -> ui.getInternals().getStateTree()
+                        .beforeClientResponse(grid.getElement().getNode(), e -> setFirstAndSecondItemsVisible()));
+    }
+
+}

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridDetailsRowPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridDetailsRowPage.java
@@ -28,15 +28,20 @@ public class GridDetailsRowPage extends Div {
     private Grid<Person> grid = new Grid<>();
     private List<Person> items = new ArrayList<>();
 
+    private int nbUpdates;
+    private Person person3 = new Person("Person 3", 2);
+    private Person person4 = new Person("Person 4", 1111);
+
     public void setFirstAndSecondItemsVisible() {
         grid.setDetailsVisible(items.get(0), true);
         grid.setDetailsVisible(items.get(1), true);
     }
     public GridDetailsRowPage() {
+
         items.add(new Person("Person 1", 99));
         items.add(new Person("Person 2", 1));
-        items.add(new Person("Person 3", 2));
-        items.add(new Person("Person 4", 1111));
+        items.add(person3);
+        items.add(person4);
 
         ListDataProvider<Person> ldp = new ListDataProvider<>(items);
         grid.setDataProvider(ldp);
@@ -50,7 +55,20 @@ public class GridDetailsRowPage extends Div {
                     setFirstAndSecondItemsVisible(); // same method call as above
                 })
         );
+        Button updatePerson3 = new Button("update and refresh person 3", e -> {
+            nbUpdates++;
+            person3.setFirstName("Person 3 - updates "+nbUpdates);
+            grid.getDataProvider().refreshItem(person3);
+        });
+        updatePerson3.setId("update-button");
+        add(updatePerson3);
 
+        Button removeButton = new Button("remove person 4", e -> {
+            items.remove(person4);
+            grid.getDataProvider().refreshAll();
+        });
+        removeButton.setId("remove-button");
+        add(removeButton);
         setFirstAndSecondItemsVisible();
     }
 

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridDetailsRowPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridDetailsRowPage.java
@@ -16,168 +16,33 @@
 package com.vaadin.flow.component.treegrid.it;
 
 import com.vaadin.flow.component.button.Button;
-import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.treegrid.TreeGrid;
+import com.vaadin.flow.data.provider.hierarchy.TreeData;
+import com.vaadin.flow.data.provider.hierarchy.TreeDataProvider;
 import com.vaadin.flow.data.renderer.ComponentRenderer;
-import com.vaadin.flow.function.ValueProvider;
+import com.vaadin.flow.function.SerializableFunction;
 import com.vaadin.flow.router.Route;
-
-import javax.swing.*;
-import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.function.BinaryOperator;
 
 @Route("treegrid-details-row")
 public class TreeGridDetailsRowPage extends Div {
 
     public TreeGridDetailsRowPage() {
 
-        BigDecimal neutral = BigDecimal.ZERO;
-        BinaryOperator<BigDecimal> sum = BigDecimal::add;
+        TreeGrid<String> treeGrid = new TreeGrid<>();
+        treeGrid.addHierarchyColumn(String::toString).setHeader("String");
+        TreeData<String> data = new TreeData<>();
+        String root = "parent1";
+        data.addItem(null, root);
+        data.addItem("parent1", "parent1-child1");
+        data.addItem("parent1", "parent1-child2");
+        data.addItem(null, "parent2");
+        data.addItem("parent2", "parent2-child2");
+        treeGrid.setDataProvider(new TreeDataProvider<>(data));
 
-        SummaryTree.Leaf<BigDecimal> node1 = new SummaryTree.Leaf<>("Eins", Arrays.asList(new BigDecimal(1), new BigDecimal(2)));
+        treeGrid.setItemDetailsRenderer(new ComponentRenderer<>((SerializableFunction<String, Button>) Button::new));
+        treeGrid.setDetailsVisible(root, true);
 
-        SummaryTree.Leaf<BigDecimal> node21 = new SummaryTree.Leaf<>("2.1", Arrays.asList(new BigDecimal(10), new BigDecimal(50)));
-        SummaryTree.Leaf<BigDecimal> node221 = new SummaryTree.Leaf<>("2.2.1", Arrays.asList(new BigDecimal(20), new BigDecimal(60)));
-        SummaryTree.Leaf<BigDecimal> node222 = new SummaryTree.Leaf<>("2.2.2", Arrays.asList(new BigDecimal(20), new BigDecimal(60)));
-        SummaryTree.SummaryNode<BigDecimal> node22 = new SummaryTree.SummaryNode<>("2.2 (multiplied)", BigDecimal.ONE, BigDecimal::multiply, node221, node222);
-        SummaryTree.Leaf<BigDecimal> node23 = new SummaryTree.Leaf<>("2.3", Arrays.asList(new BigDecimal(30), new BigDecimal(70)));
-        SummaryTree.SummaryNode<BigDecimal> node2 = new SummaryTree.SummaryNode<>("Zwei", neutral, sum, node21, node22, node23);
-
-        SummaryTree.Leaf node3 = new SummaryTree.Leaf<>("Drei", Arrays.asList(new BigDecimal(100), new BigDecimal(200)));
-
-        SummaryTree.SummaryNode<BigDecimal> summaryNode = new SummaryTree.SummaryNode<>("root", neutral, sum, node1, node2, node3);
-
-        SummaryTree summaryTree = new SummaryTree(summaryNode);
-        summaryTree.setSizeFull();
-
-        add(summaryTree);
-
-        setSizeFull();
-    }
-
-
-
-
-    public static class SummaryTree extends VerticalLayout {
-
-        @SuppressWarnings("WeakerAccess")
-        public static abstract class Node<T>{
-            private final String name;
-            Node(String name){
-                this.name = name;
-            }
-
-            final String getName(){
-                return this.name;
-            }
-
-            abstract T getValue(int which);
-            abstract int getNumberOfValues();
-            abstract Collection<Node<T>> getChildren();
-        }
-
-        public static class SummaryNode<T> extends Node<T>{
-
-            private final ArrayList<Node<T>> children = new ArrayList<>();
-
-            private final T neutral;
-            private final BinaryOperator<T> summarizer;
-
-            @SafeVarargs
-            public SummaryNode(String name, T neutral, BinaryOperator<T> summarizer, Node<T>... children) {
-                super(name);
-
-                this.neutral = neutral;
-                this.summarizer = summarizer;
-
-                this.children.addAll(Arrays.asList(children));
-            }
-
-            public T getValue(int which){
-                return children.stream().map(child->child.getValue(which)).reduce(neutral, summarizer);
-            }
-
-            public Collection<Node<T>> getChildren(){
-                return Collections.unmodifiableList(children);
-            }
-
-            @Override
-            int getNumberOfValues() {
-                if (children.isEmpty()){
-                    throw new RuntimeException("No children yet, don't know about their number of values.");
-                }
-                else{
-                    return children.get(0).getNumberOfValues();
-                }
-            }
-        }
-
-        public static class Leaf<T> extends Node<T>{
-
-            private final List<T> values;
-
-            public Leaf(String name, List<T> values) {
-                super(name);
-                this.values = Collections.unmodifiableList(values);
-            }
-
-            @Override
-            T getValue(int which) {
-                return values.get(which);
-            }
-
-            @Override
-            int getNumberOfValues() {
-                return values.size();
-            }
-
-            @Override
-            public Collection<Node<T>> getChildren(){
-                return Collections.emptyList();
-            }
-        }
-
-
-        public <T> SummaryTree (Node<T> root){
-            TreeGrid<Node<T>> treeGrid = new TreeGrid<>();
-            treeGrid.setSizeFull();
-
-            ValueProvider<Node<T>, String> vp = Node::getName;
-            Grid.Column<Node<T>> column = treeGrid.addHierarchyColumn(vp);
-            column.setHeader("Name");
-            //column.setAutoWidth(true);
-
-            for (int i = 0; i < root.getNumberOfValues(); i++) {
-                final int j=i;
-                ValueProvider<Node<T>, T> valueProvider = n->n.getValue(j);
-
-                Grid.Column<Node<T>> col = treeGrid.addColumn(valueProvider);
-                col.setHeader("Value "+j);
-                //col.setAutoWidth(true);
-            }
-
-            treeGrid.setItems(Collections.singleton(root), Node::getChildren);
-            treeGrid.expandRecursively(Collections.singleton(root), Integer.MAX_VALUE);
-
-            treeGrid.setItemDetailsRenderer(new ComponentRenderer<>(node -> new Button(node.getName() + (node.getChildren().isEmpty()? " LEAF" : " WITH CHILDREN"))));
-            treeGrid.setDetailsVisible(root, true);
-
-            Button button = new Button("setDetailsVisible(root, true) and setDetailsVisibleOnClick(true)");
-            button.addClickListener( evt -> {
-                treeGrid.setDetailsVisible(root, true);
-                treeGrid.setDetailsVisibleOnClick(true);
-            });
-
-            add(treeGrid, button);
-
-        }
-
+        add(treeGrid);
     }
 }

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridDetailsRowPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridDetailsRowPage.java
@@ -164,10 +164,10 @@ public class TreeGridDetailsRowPage extends Div {
             }
 
             treeGrid.setItems(Collections.singleton(root), Node::getChildren);
-            treeGrid.expandRecursively(Collections.singleton(root), Integer.MAX_VALUE);
+          //  treeGrid.expandRecursively(Collections.singleton(root), Integer.MAX_VALUE);
             //treeGrid.recalculateColumnWidths();
 
-            treeGrid.setItemDetailsRenderer(new ComponentRenderer<>(node -> new Button(node.getChildren().isEmpty()? "VaadinIcon.CIRCLE" : "VaadinIcon.ABACUS")));
+            treeGrid.setItemDetailsRenderer(new ComponentRenderer<>(node -> new Button(node.getName() + (node.getChildren().isEmpty()? " LEAF" : " WITH CHILDREN"))));
             //treeGrid.setItemDetailsRenderer(new ComponentRenderer<>(() -> new Button("ABACUS")));
             treeGrid.setDetailsVisible(root, true);
 

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridDetailsRowPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridDetailsRowPage.java
@@ -35,7 +35,11 @@ public class TreeGridDetailsRowPage extends Div {
         String root = "parent1";
         data.addItem(null, root);
         data.addItem("parent1", "parent1-child1");
+        data.addItem("parent1-child1", "p1-c1-c1");
+        data.addItem("parent1-child1", "p1-c1-c2");
         data.addItem("parent1", "parent1-child2");
+        data.addItem("parent1-child2", "p1-c2-c1");
+        data.addItem("parent1-child2", "p1-c2-c2");
         data.addItem(null, "parent2");
         data.addItem("parent2", "parent2-child2");
         treeGrid.setDataProvider(new TreeDataProvider<>(data));

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridDetailsRowPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridDetailsRowPage.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.treegrid.it;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.component.treegrid.TreeGrid;
+import com.vaadin.flow.data.renderer.ComponentRenderer;
+import com.vaadin.flow.function.ValueProvider;
+import com.vaadin.flow.router.Route;
+
+import javax.swing.*;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.BinaryOperator;
+
+@Route("treegrid-details-row")
+public class TreeGridDetailsRowPage extends Div {
+
+    public TreeGridDetailsRowPage() {
+
+        BigDecimal neutral = BigDecimal.ZERO;
+        BinaryOperator<BigDecimal> sum = BigDecimal::add;
+
+        SummaryTree.Leaf<BigDecimal> node1 = new SummaryTree.Leaf<>("Eins", Arrays.asList(new BigDecimal(1), new BigDecimal(2)));
+
+        SummaryTree.Leaf<BigDecimal> node21 = new SummaryTree.Leaf<>("2.1", Arrays.asList(new BigDecimal(10), new BigDecimal(50)));
+        SummaryTree.Leaf<BigDecimal> node221 = new SummaryTree.Leaf<>("2.2.1", Arrays.asList(new BigDecimal(20), new BigDecimal(60)));
+        SummaryTree.Leaf<BigDecimal> node222 = new SummaryTree.Leaf<>("2.2.2", Arrays.asList(new BigDecimal(20), new BigDecimal(60)));
+        SummaryTree.SummaryNode<BigDecimal> node22 = new SummaryTree.SummaryNode<>("2.2 (multiplied)", BigDecimal.ONE, BigDecimal::multiply, node221, node222);
+        SummaryTree.Leaf<BigDecimal> node23 = new SummaryTree.Leaf<>("2.3", Arrays.asList(new BigDecimal(30), new BigDecimal(70)));
+        SummaryTree.SummaryNode<BigDecimal> node2 = new SummaryTree.SummaryNode<>("Zwei", neutral, sum, node21, node22, node23);
+
+        SummaryTree.Leaf node3 = new SummaryTree.Leaf<>("Drei", Arrays.asList(new BigDecimal(100), new BigDecimal(200)));
+
+        SummaryTree.SummaryNode<BigDecimal> summaryNode = new SummaryTree.SummaryNode<BigDecimal>("Long long long long loooooooooong name", neutral, sum, node1, node2, node3);
+
+        SummaryTree summaryTree = new SummaryTree(summaryNode);
+        summaryTree.setSizeFull();
+
+        add(summaryTree);
+
+        setSizeFull();
+    }
+
+
+
+
+    public static class SummaryTree extends VerticalLayout {
+
+        @SuppressWarnings("WeakerAccess")
+        public static abstract class Node<T>{
+            private final String name;
+            Node(String name){
+                this.name = name;
+            }
+
+            final String getName(){
+                return this.name;
+            }
+
+            abstract T getValue(int which);
+            abstract int getNumberOfValues();
+            abstract Collection<Node<T>> getChildren();
+        }
+
+        public static class SummaryNode<T> extends Node<T>{
+
+            private final ArrayList<Node<T>> children = new ArrayList<>();
+
+            private final T neutral;
+            private final BinaryOperator<T> summarizer;
+
+            @SafeVarargs
+            public SummaryNode(String name, T neutral, BinaryOperator<T> summarizer, Node<T>... children) {
+                super(name);
+
+                this.neutral = neutral;
+                this.summarizer = summarizer;
+
+                this.children.addAll(Arrays.asList(children));
+            }
+
+            public T getValue(int which){
+                return children.stream().map(child->child.getValue(which)).reduce(neutral, summarizer);
+            }
+
+            public Collection<Node<T>> getChildren(){
+                return Collections.unmodifiableList(children);
+            }
+
+            @Override
+            int getNumberOfValues() {
+                if (children.isEmpty()){
+                    throw new RuntimeException("No children yet, don't know about their number of values.");
+                }
+                else{
+                    return children.get(0).getNumberOfValues();
+                }
+            }
+        }
+
+        public static class Leaf<T> extends Node<T>{
+
+            private final List<T> values;
+
+            public Leaf(String name, List<T> values) {
+                super(name);
+                this.values = Collections.unmodifiableList(values);
+            }
+
+            @Override
+            T getValue(int which) {
+                return values.get(which);
+            }
+
+            @Override
+            int getNumberOfValues() {
+                return values.size();
+            }
+
+            @Override
+            public Collection<Node<T>> getChildren(){
+                return Collections.emptyList();
+            }
+        }
+
+
+        public <T> SummaryTree (Node<T> root){
+            TreeGrid<Node<T>> treeGrid = new TreeGrid<>();
+            treeGrid.setSizeFull();
+
+            ValueProvider<Node<T>, String> vp = Node::getName;
+            Grid.Column<Node<T>> column = treeGrid.addHierarchyColumn(vp);
+            column.setHeader("Name");
+            //column.setAutoWidth(true);
+
+            for (int i = 0; i < root.getNumberOfValues(); i++) {
+                final int j=i;
+                ValueProvider<Node<T>, T> valueProvider = n->n.getValue(j);
+
+                Grid.Column<Node<T>> col = treeGrid.addColumn(valueProvider);
+                col.setHeader("Value "+j);
+                //col.setAutoWidth(true);
+            }
+
+            treeGrid.setItems(Collections.singleton(root), Node::getChildren);
+            treeGrid.expandRecursively(Collections.singleton(root), Integer.MAX_VALUE);
+            //treeGrid.recalculateColumnWidths();
+
+            treeGrid.setItemDetailsRenderer(new ComponentRenderer<>(node -> new Button(node.getChildren().isEmpty()? "VaadinIcon.CIRCLE" : "VaadinIcon.ABACUS")));
+            //treeGrid.setItemDetailsRenderer(new ComponentRenderer<>(() -> new Button("ABACUS")));
+            treeGrid.setDetailsVisible(root, true);
+
+            Button button = new Button("setDetailsVisible(root, true) and setDetailsVisibleOnClick(true)");
+            button.addClickListener( evt -> {
+                treeGrid.setDetailsVisible(root, true);
+                treeGrid.setDetailsVisibleOnClick(true);
+            });
+
+            add(treeGrid, button);
+
+        }
+
+    }
+}

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridDetailsRowPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridDetailsRowPage.java
@@ -27,25 +27,28 @@ import com.vaadin.flow.router.Route;
 @Route("treegrid-details-row")
 public class TreeGridDetailsRowPage extends Div {
 
+    public static final String PARENT_1_CHILD_1 = "parent1-child1";
+    public static final String PARENT_1_CHILD_2 = "parent1-child2";
+    public static final String PARENT_1 = "parent1";
+
     public TreeGridDetailsRowPage() {
 
         TreeGrid<String> treeGrid = new TreeGrid<>();
         treeGrid.addHierarchyColumn(String::toString).setHeader("String");
         TreeData<String> data = new TreeData<>();
-        String root = "parent1";
-        data.addItem(null, root);
-        data.addItem("parent1", "parent1-child1");
-        data.addItem("parent1-child1", "p1-c1-c1");
-        data.addItem("parent1-child1", "p1-c1-c2");
-        data.addItem("parent1", "parent1-child2");
-        data.addItem("parent1-child2", "p1-c2-c1");
-        data.addItem("parent1-child2", "p1-c2-c2");
+        data.addItem(null, PARENT_1);
+        data.addItem(PARENT_1, PARENT_1_CHILD_1);
+        data.addItem(PARENT_1_CHILD_1, "p1-c1-c1");
+        data.addItem(PARENT_1_CHILD_1, "p1-c1-c2");
+        data.addItem(PARENT_1, PARENT_1_CHILD_2);
+        data.addItem(PARENT_1_CHILD_2, "p1-c2-c1");
+        data.addItem(PARENT_1_CHILD_2, "p1-c2-c2");
         data.addItem(null, "parent2");
         data.addItem("parent2", "parent2-child2");
         treeGrid.setDataProvider(new TreeDataProvider<>(data));
 
         treeGrid.setItemDetailsRenderer(new ComponentRenderer<>((SerializableFunction<String, Button>) Button::new));
-        treeGrid.setDetailsVisible(root, true);
+        treeGrid.setDetailsVisible(PARENT_1, true);
 
         add(treeGrid);
     }

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridDetailsRowPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridDetailsRowPage.java
@@ -52,7 +52,7 @@ public class TreeGridDetailsRowPage extends Div {
 
         SummaryTree.Leaf node3 = new SummaryTree.Leaf<>("Drei", Arrays.asList(new BigDecimal(100), new BigDecimal(200)));
 
-        SummaryTree.SummaryNode<BigDecimal> summaryNode = new SummaryTree.SummaryNode<BigDecimal>("Long long long long loooooooooong name", neutral, sum, node1, node2, node3);
+        SummaryTree.SummaryNode<BigDecimal> summaryNode = new SummaryTree.SummaryNode<>("root", neutral, sum, node1, node2, node3);
 
         SummaryTree summaryTree = new SummaryTree(summaryNode);
         summaryTree.setSizeFull();
@@ -164,11 +164,9 @@ public class TreeGridDetailsRowPage extends Div {
             }
 
             treeGrid.setItems(Collections.singleton(root), Node::getChildren);
-          //  treeGrid.expandRecursively(Collections.singleton(root), Integer.MAX_VALUE);
-            //treeGrid.recalculateColumnWidths();
+            treeGrid.expandRecursively(Collections.singleton(root), Integer.MAX_VALUE);
 
             treeGrid.setItemDetailsRenderer(new ComponentRenderer<>(node -> new Button(node.getName() + (node.getChildren().isEmpty()? " LEAF" : " WITH CHILDREN"))));
-            //treeGrid.setItemDetailsRenderer(new ComponentRenderer<>(() -> new Button("ABACUS")));
             treeGrid.setDetailsVisible(root, true);
 
             Button button = new Button("setDetailsVisible(root, true) and setDetailsVisibleOnClick(true)");

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridDetailsRowIT.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridDetailsRowIT.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.it;
+
+import com.vaadin.flow.component.grid.testbench.GridElement;
+import com.vaadin.flow.testutil.AbstractComponentIT;
+import com.vaadin.flow.testutil.TestPath;
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import java.util.List;
+import java.util.Locale;
+
+@TestPath("grid-details-row")
+public class GridDetailsRowIT extends AbstractComponentIT {
+
+    @Test
+    public void gridNullValuesRenderedAsEmptyStrings() {
+        open();
+        GridElement grid = $(GridElement.class).first();
+        // 1 details configured
+        assertAmountOfOpenDetails(grid,1);
+
+        // each detail contain a button
+        List<WebElement> detailsElement = grid
+                .findElements(By.tagName("flow-component-renderer"));
+
+        Assert.assertEquals(2, detailsElement.size());
+
+        assertElementHasButton(detailsElement.get(0));
+        assertElementHasButton(detailsElement.get(1));
+
+    }
+
+
+    private void assertAmountOfOpenDetails(WebElement grid,
+                                           int expectedAmount) {
+        waitUntil(driver ->
+                grid.findElements(By.className("row-details")).size()
+                        == expectedAmount);
+        Assert.assertEquals(expectedAmount,
+                grid.findElements(By.className("row-details")).size());
+    }
+
+    private void assertElementHasButton(WebElement componentRenderer) {
+
+        List<WebElement> children = componentRenderer
+                .findElements(By.tagName("vaadin-button"));
+        Assert.assertEquals(1, children.size());
+
+    }
+
+}

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridDetailsRowIT.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridDetailsRowIT.java
@@ -37,6 +37,9 @@ public class GridDetailsRowIT extends AbstractComponentIT {
         //  detail configured
         assertAmountOfOpenDetails(grid,1);
 
+        waitUntil(driver -> grid
+                .findElements(By.tagName("flow-component-renderer")).size() == 2,1);
+
         // each detail contain a button
         List<WebElement> detailsElement = grid
                 .findElements(By.tagName("flow-component-renderer"));
@@ -57,9 +60,11 @@ public class GridDetailsRowIT extends AbstractComponentIT {
         // select row 3
         clickElementWithJs(getRow(grid, 3).findElement(By.tagName("td")));
 
+        waitUntil(driver -> grid
+                .findElements(By.tagName("flow-component-renderer")).size() == 3,1);
+
         List<WebElement> detailsElement = grid
                 .findElements(By.tagName("flow-component-renderer"));
-
         Assert.assertEquals(3, detailsElement.size());
 
         // detail on row 0 is empty
@@ -104,11 +109,12 @@ public class GridDetailsRowIT extends AbstractComponentIT {
         // select row 3
         clickElementWithJs(getRow(grid, 2).findElement(By.tagName("td")));
 
+        waitUntil(driver -> grid
+                .findElements(By.tagName("flow-component-renderer")).size() == 3,1);
+
         List<WebElement> detailsElement = grid
                 .findElements(By.tagName("flow-component-renderer"));
-
         Assert.assertEquals(3, detailsElement.size());
-
         // detail on row 0 is empty
         assertElementHasNoButton(detailsElement.get(0));
         // detail on row 1 is empty
@@ -119,6 +125,10 @@ public class GridDetailsRowIT extends AbstractComponentIT {
 
         WebElement updateButton = findElement(By.id("update-button"));
         updateButton.click();
+
+
+        waitUntil(driver -> grid
+                .findElements(By.tagName("flow-component-renderer")).size() == 3,1);
 
         detailsElement = grid
                 .findElements(By.tagName("flow-component-renderer"));

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridDetailsRowIT.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridDetailsRowIT.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.component.grid.it;
 import com.vaadin.flow.component.grid.testbench.GridElement;
 import com.vaadin.flow.testutil.AbstractComponentIT;
 import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.By;
@@ -30,10 +31,10 @@ import java.util.Locale;
 public class GridDetailsRowIT extends AbstractComponentIT {
 
     @Test
-    public void gridNullValuesRenderedAsEmptyStrings() {
+    public void gridTwoItemsSelectedWhenOpen() {
         open();
         GridElement grid = $(GridElement.class).first();
-        // 1 details configured
+        //  detail configured
         assertAmountOfOpenDetails(grid,1);
 
         // each detail contain a button
@@ -42,11 +43,103 @@ public class GridDetailsRowIT extends AbstractComponentIT {
 
         Assert.assertEquals(2, detailsElement.size());
 
-        assertElementHasButton(detailsElement.get(0));
-        assertElementHasButton(detailsElement.get(1));
+        assertElementHasButton(detailsElement.get(0), "Person 1");
+        assertElementHasButton(detailsElement.get(1), "Person 2");
+    }
+
+    /**
+     * Click on an item, hide the other details
+     */
+    @Test
+    public void gridSelectItem4DisplayDetails() {
+        open();
+        GridElement grid = $(GridElement.class).first();
+        // select row 3
+        clickElementWithJs(getRow(grid, 3).findElement(By.tagName("td")));
+
+        List<WebElement> detailsElement = grid
+                .findElements(By.tagName("flow-component-renderer"));
+
+        Assert.assertEquals(3, detailsElement.size());
+
+        // detail on row 0 is empty
+        assertElementHasNoButton(detailsElement.get(0));
+        // detail on row 1 is empty
+        assertElementHasNoButton(detailsElement.get(1));
+        // detail on row 3 contains a button
+        assertElementHasButton(detailsElement.get(2),"Person 4");
+    }
+
+
+    /**
+     * If the details of an item is opened and the items removed
+     * then the details should be empty
+     */
+    @Test
+    public void gridRemoveItemRemoveDetails() {
+        open();
+        GridElement grid = $(GridElement.class).first();
+        // select row 3
+        clickElementWithJs(getRow(grid, 3).findElement(By.tagName("td")));
+
+        WebElement removeButton = findElement(By.id("remove-button"));
+        // remove the last row
+        removeButton.click();
+
+        List<WebElement> detailsElementsAfterRemoval = grid
+                .findElements(By.tagName("flow-component-renderer"));
+
+        detailsElementsAfterRemoval.forEach(this::assertElementHasNoButton);
 
     }
 
+    /**
+     * If the details of an item is opened
+     * and the item updated then the detail should be updated
+     */
+    @Test
+    public void gridUpdateItemUpdateDetails() {
+        open();
+        GridElement grid = $(GridElement.class).first();
+        // select row 3
+        clickElementWithJs(getRow(grid, 2).findElement(By.tagName("td")));
+
+        List<WebElement> detailsElement = grid
+                .findElements(By.tagName("flow-component-renderer"));
+
+        Assert.assertEquals(3, detailsElement.size());
+
+        // detail on row 0 is empty
+        assertElementHasNoButton(detailsElement.get(0));
+        // detail on row 1 is empty
+        assertElementHasNoButton(detailsElement.get(1));
+        // detail on row 3 contains a button
+        assertElementHasButton(detailsElement.get(2),"Person 3");
+
+
+        WebElement updateButton = findElement(By.id("update-button"));
+        updateButton.click();
+
+        detailsElement = grid
+                .findElements(By.tagName("flow-component-renderer"));
+
+        Assert.assertEquals(3, detailsElement.size());
+
+        // detail on row 0 is empty
+        assertElementHasNoButton(detailsElement.get(0));
+        // detail on row 1 is empty
+        assertElementHasNoButton(detailsElement.get(1));
+        // detail on row 3 contains a button
+        assertElementHasButton(detailsElement.get(2),"Person 3 - updates 1");
+
+
+
+    }
+
+    private WebElement getRow(WebElement grid, int row) {
+        return getInShadowRoot(grid, By.id("items"))
+                .findElements(By.cssSelector("tr")).get(row);
+    }
 
     private void assertAmountOfOpenDetails(WebElement grid,
                                            int expectedAmount) {
@@ -57,12 +150,19 @@ public class GridDetailsRowIT extends AbstractComponentIT {
                 grid.findElements(By.className("row-details")).size());
     }
 
-    private void assertElementHasButton(WebElement componentRenderer) {
+    private void assertElementHasButton(WebElement componentRenderer, String content) {
 
         List<WebElement> children = componentRenderer
                 .findElements(By.tagName("vaadin-button"));
         Assert.assertEquals(1, children.size());
-
+        Assert.assertEquals(content, children.get(0).getText());
     }
 
+    private void assertElementHasNoButton(WebElement componentRenderer) {
+
+        List<WebElement> children = componentRenderer
+                .findElements(By.tagName("vaadin-button"));
+        Assert.assertEquals(0, children.size());
+
+    }
 }

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridDetailsRowIT.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridDetailsRowIT.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.treegrid.it;
+
+import com.vaadin.flow.component.grid.testbench.GridElement;
+import com.vaadin.flow.component.grid.testbench.TreeGridElement;
+import com.vaadin.flow.testutil.AbstractComponentIT;
+import com.vaadin.flow.testutil.TestPath;
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import java.util.List;
+
+@TestPath("treegrid-details-row")
+public class TreeGridDetailsRowIT extends AbstractComponentIT {
+
+    @Test
+    public void gridRootItemDetailsDisplayedWhenOpen() {
+        open();
+        TreeGridElement treegrid = $(TreeGridElement.class).first();
+        //  detail configured
+        assertAmountOfOpenDetails(treegrid,1);
+
+        // each detail contain a button
+        List<WebElement> detailsElement = treegrid
+                .findElements(By.tagName("flow-component-renderer"));
+
+        Assert.assertEquals(1, detailsElement.size());
+
+        assertElementHasButton(detailsElement.get(0), "root WITH CHILDREN");
+    }
+
+    @Test
+    public void gridChildItemDetailsDisplayedWhenClicked() {
+        open();
+        TreeGridElement treegrid = $(TreeGridElement.class).first();
+        //  detail configured
+        assertAmountOfOpenDetails(treegrid,1);
+
+        clickElementWithJs(getRow(treegrid, 8).findElement(By.tagName("td")));
+
+        List<WebElement> detailsElement = treegrid
+                .findElements(By.tagName("flow-component-renderer"));
+
+        Assert.assertEquals(2, detailsElement.size());
+
+        // detail on row 0 is empty
+        assertElementHasNoButton(detailsElement.get(0));
+        // detail on row 1 contains a button
+        assertElementHasButton(detailsElement.get(1),"Drei LEAF");
+    }
+
+    private WebElement getRow(WebElement grid, int row) {
+        return getInShadowRoot(grid, By.id("items"))
+                .findElements(By.cssSelector("tr")).get(row);
+    }
+
+    private void assertAmountOfOpenDetails(WebElement grid,
+                                           int expectedAmount) {
+        waitUntil(driver ->
+                grid.findElements(By.className("row-details")).size()
+                        == expectedAmount);
+        Assert.assertEquals(expectedAmount,
+                grid.findElements(By.className("row-details")).size());
+    }
+
+    private void assertElementHasButton(WebElement componentRenderer, String content) {
+
+        List<WebElement> children = componentRenderer
+                .findElements(By.tagName("vaadin-button"));
+        Assert.assertEquals(1, children.size());
+        Assert.assertEquals(content, children.get(0).getText());
+    }
+
+    private void assertElementHasNoButton(WebElement componentRenderer) {
+
+        List<WebElement> children = componentRenderer
+                .findElements(By.tagName("vaadin-button"));
+        Assert.assertEquals(0, children.size());
+
+    }
+}

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridDetailsRowIT.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridDetailsRowIT.java
@@ -36,6 +36,9 @@ public class TreeGridDetailsRowIT extends AbstractComponentIT {
         //  detail configured
         assertAmountOfOpenDetails(treegrid,1);
 
+        waitUntil(driver -> treegrid
+                .findElements(By.tagName("flow-component-renderer")).size() == 1,1);
+
         // each detail contain a button
         List<WebElement> detailsElement = treegrid
                 .findElements(By.tagName("flow-component-renderer"));
@@ -53,6 +56,9 @@ public class TreeGridDetailsRowIT extends AbstractComponentIT {
         assertAmountOfOpenDetails(treegrid,1);
         treegrid.expandWithClick(0);
         clickElementWithJs(getRow(treegrid, 2).findElement(By.tagName("td")));
+
+        waitUntil(driver -> treegrid
+                .findElements(By.tagName("flow-component-renderer")).size() == 2,1);
 
         List<WebElement> detailsElement = treegrid
                 .findElements(By.tagName("flow-component-renderer"));
@@ -75,6 +81,9 @@ public class TreeGridDetailsRowIT extends AbstractComponentIT {
         treegrid.collapseWithClick(0);
         treegrid.expandWithClick(0);
         clickElementWithJs(getRow(treegrid, 2).findElement(By.tagName("td")));
+
+        waitUntil(driver -> treegrid
+                .findElements(By.tagName("flow-component-renderer")).size() == 2,1);
 
         List<WebElement> detailsElement = treegrid
                 .findElements(By.tagName("flow-component-renderer"));
@@ -99,15 +108,17 @@ public class TreeGridDetailsRowIT extends AbstractComponentIT {
         treegrid.expandWithClick(1);
         clickElementWithJs(getRow(treegrid, 2).findElement(By.tagName("td")));
 
+        waitUntil(driver -> treegrid
+                .findElements(By.tagName("flow-component-renderer")).size() == 2,1);
+
         List<WebElement> detailsElement = treegrid
                 .findElements(By.tagName("flow-component-renderer"));
 
         Assert.assertEquals(" Details for parent2-child1 is not displayed",2, detailsElement.size());
-
         // detail on row 0 is empty
         assertElementHasNoButton(detailsElement.get(0));
         // detail on row 1 contains a button
-        assertElementHasButton(detailsElement.get(1),"parent2-child2");
+        assertElementHasButton(detailsElement.get(1), "parent2-child2");
     }
 
     private WebElement getRow(WebElement grid, int row) {

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridDetailsRowIT.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridDetailsRowIT.java
@@ -65,6 +65,30 @@ public class TreeGridDetailsRowIT extends AbstractComponentIT {
         assertElementHasButton(detailsElement.get(1),"Drei LEAF");
     }
 
+    @Test
+    public void gridChildItemDetailsDisplayedAfterCollapseWhenClicked() {
+        open();
+        TreeGridElement treegrid = $(TreeGridElement.class).first();
+        //  detail configured
+        assertAmountOfOpenDetails(treegrid,1);
+
+        treegrid.collapseWithClick(0);
+        treegrid.expandWithClick(0);
+
+        clickElementWithJs(getRow(treegrid, 8).findElement(By.tagName("td")));
+
+        List<WebElement> detailsElement = treegrid
+                .findElements(By.tagName("flow-component-renderer"));
+
+        Assert.assertEquals(2, detailsElement.size());
+
+        // detail on row 0 is empty
+        assertElementHasNoButton(detailsElement.get(0));
+        // assertElementHasNoButton(detailsElement.get(0));
+        // detail on row 1 contains a button
+        assertElementHasButton(detailsElement.get(1),"Drei LEAF");
+    }
+
     private WebElement getRow(WebElement grid, int row) {
         return getInShadowRoot(grid, By.id("items"))
                 .findElements(By.cssSelector("tr")).get(row);

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridDetailsRowIT.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridDetailsRowIT.java
@@ -87,6 +87,29 @@ public class TreeGridDetailsRowIT extends AbstractComponentIT {
         assertElementHasButton(detailsElement.get(1),"parent1-child2");
     }
 
+
+    @Test
+    public void gridChildItemDetailsDisplayedAfterCollapse2WhenClicked() {
+        open();
+        TreeGridElement treegrid = $(TreeGridElement.class).first();
+        //  detail configured
+        assertAmountOfOpenDetails(treegrid,1);
+        treegrid.expandWithClick(1);
+        treegrid.collapseWithClick(1);
+        treegrid.expandWithClick(1);
+        clickElementWithJs(getRow(treegrid, 2).findElement(By.tagName("td")));
+
+        List<WebElement> detailsElement = treegrid
+                .findElements(By.tagName("flow-component-renderer"));
+
+        Assert.assertEquals(" Details for parent2-child1 is not displayed",2, detailsElement.size());
+
+        // detail on row 0 is empty
+        assertElementHasNoButton(detailsElement.get(0));
+        // detail on row 1 contains a button
+        assertElementHasButton(detailsElement.get(1),"parent2-child2");
+    }
+
     private WebElement getRow(WebElement grid, int row) {
         return getInShadowRoot(grid, By.id("items"))
                 .findElements(By.cssSelector("tr")).get(row);

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridDetailsRowIT.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridDetailsRowIT.java
@@ -42,7 +42,7 @@ public class TreeGridDetailsRowIT extends AbstractComponentIT {
 
         Assert.assertEquals(1, detailsElement.size());
 
-        assertElementHasButton(detailsElement.get(0), "root WITH CHILDREN");
+        assertElementHasButton(detailsElement.get(0), "parent1");
     }
 
     @Test
@@ -51,8 +51,8 @@ public class TreeGridDetailsRowIT extends AbstractComponentIT {
         TreeGridElement treegrid = $(TreeGridElement.class).first();
         //  detail configured
         assertAmountOfOpenDetails(treegrid,1);
-
-        clickElementWithJs(getRow(treegrid, 8).findElement(By.tagName("td")));
+        treegrid.expandWithClick(0);
+        clickElementWithJs(getRow(treegrid, 2).findElement(By.tagName("td")));
 
         List<WebElement> detailsElement = treegrid
                 .findElements(By.tagName("flow-component-renderer"));
@@ -62,7 +62,7 @@ public class TreeGridDetailsRowIT extends AbstractComponentIT {
         // detail on row 0 is empty
         assertElementHasNoButton(detailsElement.get(0));
         // detail on row 1 contains a button
-        assertElementHasButton(detailsElement.get(1),"Drei LEAF");
+        assertElementHasButton(detailsElement.get(1),"parent1-child2");
     }
 
     @Test
@@ -71,22 +71,20 @@ public class TreeGridDetailsRowIT extends AbstractComponentIT {
         TreeGridElement treegrid = $(TreeGridElement.class).first();
         //  detail configured
         assertAmountOfOpenDetails(treegrid,1);
-
+        treegrid.expandWithClick(0);
         treegrid.collapseWithClick(0);
         treegrid.expandWithClick(0);
-
-        clickElementWithJs(getRow(treegrid, 8).findElement(By.tagName("td")));
+        clickElementWithJs(getRow(treegrid, 2).findElement(By.tagName("td")));
 
         List<WebElement> detailsElement = treegrid
                 .findElements(By.tagName("flow-component-renderer"));
 
-        Assert.assertEquals(2, detailsElement.size());
+        Assert.assertEquals(" Details for parent1-child2 is not displayed",2, detailsElement.size());
 
         // detail on row 0 is empty
         assertElementHasNoButton(detailsElement.get(0));
-        // assertElementHasNoButton(detailsElement.get(0));
         // detail on row 1 contains a button
-        assertElementHasButton(detailsElement.get(1),"Drei LEAF");
+        assertElementHasButton(detailsElement.get(1),"parent1-child2");
     }
 
     private WebElement getRow(WebElement grid, int row) {
@@ -115,7 +113,7 @@ public class TreeGridDetailsRowIT extends AbstractComponentIT {
 
         List<WebElement> children = componentRenderer
                 .findElements(By.tagName("vaadin-button"));
-        Assert.assertEquals(0, children.size());
+        Assert.assertTrue("Details should be empty or not visible",(children.size() == 0)||(!children.get(0).isDisplayed()));
 
     }
 }

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridHugeTreeIT.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridHugeTreeIT.java
@@ -107,7 +107,7 @@ public class TreeGridHugeTreeIT extends AbstractTreeGridIT {
 
         grid.expandWithClick(1);
         waitUntil(tets -> grid.getNumberOfExpandedRows() == 99);
-        waitUntil(test -> !grid.isLoadingExpandedRows());
+        waitUntil(test -> !grid.isLoadingExpandedRows(),25);
 
         assertCellTexts(0, 0, cellTexts);
     }

--- a/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -1013,17 +1013,24 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
             }
         }
 
+        /**
+         * Remove the displayed details and remove details item from the list
+         *
+         * @param item item to removed
+         */
         @Override
         public void destroyData(T item) {
-          //  detailsVisible.remove(item);
+            detailsVisible.remove(item);
             if (itemDetailsDataGenerator != null) {
                 itemDetailsDataGenerator.destroyData(item);
             }
         }
 
+        /**
+         * Remove the displayed details but keep the items from list of details
+         */
         @Override
         public void destroyAllData() {
-         //   detailsVisible.clear();
             if (itemDetailsDataGenerator != null) {
                 itemDetailsDataGenerator.destroyAllData();
             }

--- a/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -1015,7 +1015,7 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
 
         @Override
         public void destroyData(T item) {
-            detailsVisible.remove(item);
+          //  detailsVisible.remove(item);
             if (itemDetailsDataGenerator != null) {
                 itemDetailsDataGenerator.destroyData(item);
             }
@@ -1023,7 +1023,7 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
 
         @Override
         public void destroyAllData() {
-            detailsVisible.clear();
+         //   detailsVisible.clear();
             if (itemDetailsDataGenerator != null) {
                 itemDetailsDataGenerator.destroyAllData();
             }

--- a/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -218,7 +218,7 @@ window.Vaadin.Flow.gridConnector = {
       }
       // when grid is attached, newVal is not set and oldVal is undefined
       // do nothing
-      if ((newVal == null) && (typeof oldVal === 'undefined')) {
+      if ((newVal == null) && (oldVal === 'undefined')) {
         return;
       }
       if (newVal && !newVal.detailsOpened) {

--- a/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -463,14 +463,9 @@ window.Vaadin.Flow.gridConnector = {
         if (parentCache && parentCache.itemkeyCaches && parentCache.itemkeyCaches[parentKey]) {
           delete parentCache.itemkeyCaches[parentKey];
         }
-        if (parentCache && parentCache.itemCaches) {
-          const keys = Object.keys(parentCache.itemCaches);
-          for (var i = 0; i < keys.length; i++) {
-            if ( parentCache.items[keys[i]].key === parentKey) {
-              delete parentCache.itemCaches[keys[i]];
-            }
-          }
-        }
+        Object.keys(parentCache.itemCaches)
+            .filter(idx => parentCache.items[idx].key === parentKey)
+            .forEach(idx => delete parentCache.itemCaches[idx]);
         delete lastRequestedRanges[parentKey];
         this.collapseItem(inst.item);
       }

--- a/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -467,7 +467,7 @@ window.Vaadin.Flow.gridConnector = {
           const keys = Object.keys(parentCache.itemCaches);
           for (var i = 0; i < keys.length; i++) {
             if ( parentCache.items[keys[i]].key === parentKey) {
-              delete parentCache.itemCaches[i];
+              delete parentCache.itemCaches[keys[i]];
             }
           }
         }

--- a/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -216,6 +216,11 @@ window.Vaadin.Flow.gridConnector = {
       if(!detailsVisibleOnClick) {
         return;
       }
+      // when grid is attached, newVal is not set and oldVal is undefined
+      // do nothing
+      if ((newVal == null) && (typeof oldVal === 'undefined')) {
+        return;
+      }
       if (newVal && !newVal.detailsOpened) {
         grid.$server.setDetailsVisible(newVal.key);
       } else {

--- a/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -463,9 +463,11 @@ window.Vaadin.Flow.gridConnector = {
         if (parentCache && parentCache.itemkeyCaches && parentCache.itemkeyCaches[parentKey]) {
           delete parentCache.itemkeyCaches[parentKey];
         }
-        Object.keys(parentCache.itemCaches)
-            .filter(idx => parentCache.items[idx].key === parentKey)
-            .forEach(idx => delete parentCache.itemCaches[idx]);
+        if (parentCache && parentCache.itemkeyCaches) {
+          Object.keys(parentCache.itemCaches)
+              .filter(idx => parentCache.items[idx].key === parentKey)
+              .forEach(idx => delete parentCache.itemCaches[idx]);
+        }
         delete lastRequestedRanges[parentKey];
         this.collapseItem(inst.item);
       }

--- a/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -463,11 +463,15 @@ window.Vaadin.Flow.gridConnector = {
         if (parentCache && parentCache.itemkeyCaches && parentCache.itemkeyCaches[parentKey]) {
           delete parentCache.itemkeyCaches[parentKey];
         }
-        if (parentCache && parentCache.itemCaches && parentCache.itemCaches[parentKey]) {
-          delete parentCache.itemCaches[parentKey];
+        if (parentCache && parentCache.itemCaches) {
+          const keys = Object.keys(parentCache.itemCaches);
+          for (var i = 0; i < keys.length; i++) {
+            if ( parentCache.items[keys[i]].key === parentKey) {
+              delete parentCache.itemCaches[i];
+            }
+          }
         }
         delete lastRequestedRanges[parentKey];
-
         this.collapseItem(inst.item);
       }
     }

--- a/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -218,7 +218,7 @@ window.Vaadin.Flow.gridConnector = {
       }
       // when grid is attached, newVal is not set and oldVal is undefined
       // do nothing
-      if ((newVal == null) && (oldVal === 'undefined')) {
+      if ((newVal == null) && (oldVal === undefined)) {
         return;
       }
       if (newVal && !newVal.detailsOpened) {


### PR DESCRIPTION
This pull request fixes:
- #701 
and #525  (PR: https://github.com/vaadin/vaadin-grid-flow/pull/731 )

The cache was not clear correctly when a node is collapsed. So it was not rebuilt when the node expands.
There may be a better way to clear the cache.

Requires this change ( vaadin/flow#6144 ) to be merged in flow or the details will displayed but empty.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-flow/732)
<!-- Reviewable:end -->
