### PR TITLE
Add support for listening for column-reorder event from the server-side

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>vaadin-grid-flow-parent</artifactId>
-    <version>4.0-SNAPSHOT</version>
+    <version>4.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Vaadin Grid Flow Parent</name>
     

--- a/vaadin-grid-flow-demo/pom.xml
+++ b/vaadin-grid-flow-demo/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-grid-flow-parent</artifactId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-grid-flow-demo</artifactId>

--- a/vaadin-grid-flow-demo/src/main/java/com/vaadin/flow/component/grid/demo/GridDemo.java
+++ b/vaadin-grid-flow-demo/src/main/java/com/vaadin/flow/component/grid/demo/GridDemo.java
@@ -615,6 +615,7 @@ public class GridDemo extends DemoView {
         createAutoWidthColumns();
         createFrozenColumns();
         createColumnAlignment();
+        columnReorder();
         createHeaderAndFooter();// Header and footer
         createColumnGrouping();
         createHeaderAndFooterUsingComponents();
@@ -1302,6 +1303,34 @@ public class GridDemo extends DemoView {
         alignments.setId("column-alignment-example-alignments");
         addCard("Configuring columns", "Column alignment example", grid,
                 alignments);
+    }
+
+    private void columnReorder() {
+        // begin-source-example
+        // source-example-heading: Column reorder example
+        List<Person> personList = getItems();
+        Grid<Person> grid = new Grid<>();
+
+        grid.setItems(personList);
+
+        grid.addColumn(Person::getFirstName).setHeader("First Name").setKey("firstName");
+        grid.addColumn(Person::getLastName).setHeader("Last Name").setKey("lastName");
+        grid.addColumn(Person::getAge).setHeader("Age").setKey("age");
+        grid.addColumn(Person::getEmail).setHeader("Email").setKey("email");
+        grid.addColumn(Person::getPhoneNumber).setHeader("Phone Number").setKey("phoneNo");
+        grid.addColumn(Person::getBirthDate).setHeader("Birth Date").setKey("birthDate");
+
+        Span columnOrder = new Span();
+
+        grid.setColumnReorderingAllowed(true);
+        grid.addColumnReorderListener(event ->
+                columnOrder.setText(event.getColumns().stream()
+                        .map(it -> it.getKey()).collect(Collectors.joining(", "))));
+
+        // end-source-example
+        grid.setId("column-reorder-example");
+        addCard("Configuring columns", "Column reorder example",
+                grid, columnOrder);
     }
 
     // Header and footer begin

--- a/vaadin-grid-flow-demo/src/main/java/com/vaadin/flow/component/grid/demo/GridDemo.java
+++ b/vaadin-grid-flow-demo/src/main/java/com/vaadin/flow/component/grid/demo/GridDemo.java
@@ -1325,7 +1325,7 @@ public class GridDemo extends DemoView {
         grid.setColumnReorderingAllowed(true);
         grid.addColumnReorderListener(event ->
                 columnOrder.setText(event.getColumns().stream()
-                        .map(it -> it.getKey()).collect(Collectors.joining(", "))));
+                        .map(Column::getKey).collect(Collectors.joining(", "))));
 
         // end-source-example
         grid.setId("column-reorder-example");

--- a/vaadin-grid-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-grid-flow-integration-tests/pom-bower-mode.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-grid-flow-parent</artifactId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-grid-flow-integration-tests-bower-mode</artifactId>

--- a/vaadin-grid-flow-integration-tests/pom.xml
+++ b/vaadin-grid-flow-integration-tests/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-grid-flow-parent</artifactId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-grid-flow-integration-tests</artifactId>

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridTestPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridTestPage.java
@@ -19,6 +19,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 
 import com.vaadin.flow.component.HasComponents;
 import com.vaadin.flow.component.grid.Grid;
@@ -26,6 +27,7 @@ import com.vaadin.flow.component.grid.Grid.Column;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Label;
 import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.data.renderer.ComponentRenderer;
 import com.vaadin.flow.data.renderer.TemplateRenderer;
 import com.vaadin.flow.router.Route;
@@ -86,13 +88,13 @@ public class GridTestPage extends Div {
             label.setId("grid-with-component-renderers-item-name-"
                     + item.getNumber());
             return label;
-        }));
+        })).setKey("name").setHeader("Name");
         grid.addColumn(new ComponentRenderer<>(item -> {
             Label label = new Label(String.valueOf(item.getNumber()));
             label.setId("grid-with-component-renderers-item-number-"
                     + item.getNumber());
             return label;
-        }));
+        })).setKey("number").setHeader("Number");
         grid.addColumn(new ComponentRenderer<>(item -> {
             NativeButton remove = new NativeButton("Remove", evt -> {
                 if (usingFirstList.get()) {
@@ -105,7 +107,7 @@ public class GridTestPage extends Div {
             remove.setId(
                     "grid-with-component-renderers-remove-" + item.getNumber());
             return remove;
-        }));
+        })).setKey("remove");
 
         grid.setId("grid-with-component-renderers");
         grid.setWidth("500px");
@@ -124,7 +126,14 @@ public class GridTestPage extends Div {
             grid.setColumnReorderingAllowed(!grid.isColumnReorderingAllowed());
         });
         toggleColumnOrdering.setId("toggle-column-ordering");
-        add(grid, changeList, toggleColumnOrdering);
+
+        Span currentColumnOrdering = new Span();
+        currentColumnOrdering.setId("current-column-ordering");
+        grid.addColumnReorderListener(e -> currentColumnOrdering.setText(e.getColumns().stream()
+                .map(Column::getKey)
+                .collect(Collectors.joining(", "))));
+
+        add(grid, changeList, toggleColumnOrdering, currentColumnOrdering);
     }
 
     private void createGridWithTemplateDetailsRow() {

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridTestPageIT.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridTestPageIT.java
@@ -388,6 +388,16 @@ public class GridTestPageIT extends AbstractComponentIT {
         Assert.assertEquals("Item 0", grid.getCell(0, 0).getText());
     }
 
+    @Test
+    public void mockedColumnReorderEvent_smokeTest() {
+        findElement(By.id("toggle-column-ordering")).click();
+        GridElement grid = $(GridElement.class).id("grid-with-component-renderers");
+        grid.getCommandExecutor().executeScript("arguments[0].dispatchEvent(new CustomEvent('column-reorder', {detail: { columns: [{_flowId:'col1'}, {_flowId:'col0'}] }}));", grid.getWrappedElement());
+
+        final WebElement currentColumnOrdering = findElement(By.id("current-column-ordering"));
+        Assert.assertEquals("number, name", currentColumnOrdering.getText());
+    }
+
     private void assertSelection(WebElement grid, String value) {
         Assert.assertTrue(value + " should be selected",
                 (Boolean) executeScript(

--- a/vaadin-grid-flow-testbench/pom.xml
+++ b/vaadin-grid-flow-testbench/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-grid-flow-parent</artifactId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-grid-testbench</artifactId>

--- a/vaadin-grid-flow/pom.xml
+++ b/vaadin-grid-flow/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-grid-flow-parent</artifactId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-grid-flow</artifactId>

--- a/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/ColumnReorderEvent.java
+++ b/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/ColumnReorderEvent.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid;
+
+import com.vaadin.flow.component.ComponentEvent;
+import com.vaadin.flow.component.DomEvent;
+import com.vaadin.flow.component.EventData;
+import elemental.json.JsonArray;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Event fired when the columns in the Grid are reordered.
+ *
+ * @param <T>
+ *            the grid bean type
+ *
+ * @author Vaadin Ltd
+ *
+ * @see Grid#addColumnReorderListener(com.vaadin.flow.component.ComponentEventListener)
+ *
+ */
+@DomEvent("column-reorder")
+public class ColumnReorderEvent<T> extends ComponentEvent<Grid<T>> {
+
+    private final List<Grid.Column<T>> columns = new ArrayList<>();
+
+    /**
+     * Creates a new column reorder event.
+     *
+     * @param source
+     *            the component that fired the event
+     * @param fromClient
+     *            <code>true</code> if the event was originally fired on the
+     *            client, <code>false</code> if the event originates from
+     *            server-side logic
+     * @param columnIDs the internal column IDs; automatically translated to
+     *            proper Grid Column instances.
+     *
+     */
+    public ColumnReorderEvent(Grid<T> source, boolean fromClient,
+                              @EventData("event.detail.columns.map(col => col._flowId)") JsonArray columnIDs) {
+        super(source, fromClient);
+        for (int i = 0; i < columnIDs.length(); i++) {
+            final String columnID = columnIDs.getString(i);
+            columns.add(findByColumnId(columnID));
+        }
+    }
+
+    /**
+     * Gets the new order of the columns.
+     *
+     * @return the list of columns, not null, unmodifiable.
+     */
+    public List<Grid.Column<T>> getColumns() {
+        return Collections.unmodifiableList(columns);
+    }
+
+    private Grid.Column<T> findByColumnId(String id) {
+        return getSource().getColumns().stream()
+                .filter(it -> id.equals(it.getInternalId()))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("No column with ID " + id));
+    }
+}

--- a/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -3675,4 +3675,17 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
 
     }
 
+    /**
+     * Adds a column reorder listener to this component.
+     *
+     * @param listener
+     *            the listener to add, not <code>null</code>
+     * @return a handle that can be used for removing the listener
+     */
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public Registration addColumnReorderListener(
+            ComponentEventListener<ColumnReorderEvent<T>> listener) {
+        return addListener(ColumnReorderEvent.class,
+                (ComponentEventListener) Objects.requireNonNull(listener));
+    }
 }


### PR DESCRIPTION
The PR adds the `ColumnReorderEvent` class and `Grid.addColumnReorderListener()`. I've also implemented a demo page in GridDemo.

Fixes https://github.com/vaadin/vaadin-grid-flow/issues/755.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-flow/756)
<!-- Reviewable:end -->
