### PR TITLE
ItemClickListener.getColumn

### DIFF
--- a/vaadin-grid-flow-demo/src/main/java/com/vaadin/flow/component/grid/demo/GridDemo.java
+++ b/vaadin-grid-flow-demo/src/main/java/com/vaadin/flow/component/grid/demo/GridDemo.java
@@ -1831,7 +1831,7 @@ public class GridDemo extends DemoView {
                 event -> {
                     name.setText(event.getItem().getFirstName());
                     age.setText(String.valueOf(event.getItem().getAge()));
-                    event.getColumn().ifPresent(col -> column.setText(col.getKey()));
+                    column.setText(event.getColumn().getKey());
                 });
 
         // end-source-example

--- a/vaadin-grid-flow-demo/src/main/java/com/vaadin/flow/component/grid/demo/GridDemo.java
+++ b/vaadin-grid-flow-demo/src/main/java/com/vaadin/flow/component/grid/demo/GridDemo.java
@@ -1810,13 +1810,14 @@ public class GridDemo extends DemoView {
         FormLayout formLayout = new FormLayout();
         Label name = new Label();
         Label age = new Label();
+        Label column = new Label();
 
         // begin-source-example
         // source-example-heading: Item Click Listener
         Grid<Person> grid = new Grid<>();
         grid.setItems(getItems());
-        grid.addColumn(Person::getFirstName).setHeader("First Name");
-        grid.addColumn(Person::getAge).setHeader("Age");
+        grid.addColumn(Person::getFirstName).setHeader("First Name").setKey("First Name").setId("first name");
+        grid.addColumn(Person::getAge).setHeader("Age").setKey("Age");
 
         // Disable selection: will receive only click events instead
         grid.setSelectionMode(Grid.SelectionMode.NONE);
@@ -1824,11 +1825,18 @@ public class GridDemo extends DemoView {
         formLayout.add(name, age);
         formLayout.addFormItem(name, "Name");
         formLayout.addFormItem(age, "Age");
+        formLayout.addFormItem(column, "Column");
 
         grid.addItemClickListener(
                 event -> {
                     name.setText(event.getItem().getFirstName());
                     age.setText(String.valueOf(event.getItem().getAge()));
+                    if(event.getColumn().isPresent()) {
+                        column.setText(event.getColumn().get().getKey());
+                    }
+                    else {
+                        column.setText("(undefined column");
+                    }
                 });
 
         // end-source-example

--- a/vaadin-grid-flow-demo/src/main/java/com/vaadin/flow/component/grid/demo/GridDemo.java
+++ b/vaadin-grid-flow-demo/src/main/java/com/vaadin/flow/component/grid/demo/GridDemo.java
@@ -1816,7 +1816,7 @@ public class GridDemo extends DemoView {
         // source-example-heading: Item Click Listener
         Grid<Person> grid = new Grid<>();
         grid.setItems(getItems());
-        grid.addColumn(Person::getFirstName).setHeader("First Name").setKey("First Name").setId("first name");
+        grid.addColumn(Person::getFirstName).setHeader("First Name").setKey("First Name");
         grid.addColumn(Person::getAge).setHeader("Age").setKey("Age");
 
         // Disable selection: will receive only click events instead
@@ -1831,12 +1831,7 @@ public class GridDemo extends DemoView {
                 event -> {
                     name.setText(event.getItem().getFirstName());
                     age.setText(String.valueOf(event.getItem().getAge()));
-                    if(event.getColumn().isPresent()) {
-                        column.setText(event.getColumn().get().getKey());
-                    }
-                    else {
-                        column.setText("(undefined column");
-                    }
+                    event.getColumn().ifPresent(col -> column.setText(event.getColumn().get().getKey()));
                 });
 
         // end-source-example

--- a/vaadin-grid-flow-demo/src/main/java/com/vaadin/flow/component/grid/demo/GridDemo.java
+++ b/vaadin-grid-flow-demo/src/main/java/com/vaadin/flow/component/grid/demo/GridDemo.java
@@ -1831,7 +1831,7 @@ public class GridDemo extends DemoView {
                 event -> {
                     name.setText(event.getItem().getFirstName());
                     age.setText(String.valueOf(event.getItem().getAge()));
-                    event.getColumn().ifPresent(col -> column.setText(event.getColumn().get().getKey()));
+                    event.getColumn().ifPresent(col -> column.setText(col.getKey()));
                 });
 
         // end-source-example

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/ItemClickListenerPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/ItemClickListenerPage.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.component.grid.it;
 
 import com.vaadin.flow.component.checkbox.Checkbox;
 import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.grid.ItemClickEvent;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.router.Route;
 
@@ -30,17 +31,35 @@ public class ItemClickListenerPage extends Div {
         Div dblClickMsg = new Div();
         dblClickMsg.setId("dblClickMsg");
 
+        Div columnKeyMsg = new Div();
+        columnKeyMsg.setId("columnClickMsg");
+
         Grid<String> grid = new Grid<>();
         grid.setItems("foo", "bar");
-        grid.addColumn(item -> item).setHeader("Name");
+        grid.addColumn(item -> item).setHeader("Name").setKey("Name");
         grid.addComponentColumn(item -> new Checkbox(item));
 
-        grid.addItemClickListener(event -> clickMsg.add(event.getItem()));
+        grid.addItemClickListener(event -> {
+            clickMsg.add(event.getItem());
+            columnKeyMsg.add(getColumnKeyFromEvent(event));
+        });
 
-        grid.addItemDoubleClickListener(event -> dblClickMsg
-                .setText(String.valueOf(event.getClientY())));
+        grid.addItemDoubleClickListener(event -> {
+            dblClickMsg
+                    .setText(String.valueOf(event.getClientY()));
+            columnKeyMsg.setText(getColumnKeyFromEvent(event));
+        });
 
         add(grid, clickMsg, dblClickMsg);
+    }
+
+    private static String getColumnKeyFromEvent(ItemClickEvent<?> event) {
+        if(event.getColumn().isPresent()) {
+            return event.getColumn().get().getKey();
+        }
+        else {
+            return "(cannot get clicked column key!)";
+        }
     }
 
 }

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/ItemClickListenerPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/ItemClickListenerPage.java
@@ -50,9 +50,8 @@ public class ItemClickListenerPage extends Div {
         });
 
         grid.addItemDoubleClickListener(event -> {
-            dblClickMsg
-                    .setText(String.valueOf(event.getClientY()));
-            columnDblClickMsg.setText(event.getColumn().getKey());
+            dblClickMsg.add(String.valueOf(event.getClientY()));
+            columnDblClickMsg.add(event.getColumn().getKey());
         });
 
         grid.setItemDetailsRenderer(new ComponentRenderer<>((SerializableFunction<String, Span>) ItemClickListenerPage::getDetailsComponent));

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/ItemClickListenerPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/ItemClickListenerPage.java
@@ -17,7 +17,6 @@ package com.vaadin.flow.component.grid.it;
 
 import com.vaadin.flow.component.checkbox.Checkbox;
 import com.vaadin.flow.component.grid.Grid;
-import com.vaadin.flow.component.grid.ItemClickEvent;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.data.renderer.ComponentRenderer;
@@ -43,17 +42,17 @@ public class ItemClickListenerPage extends Div {
         Grid<String> grid = new Grid<>();
         grid.setItems("foo", "bar");
         grid.addColumn(item -> item).setHeader("Name").setKey("Name");
-        grid.addComponentColumn(item -> new Checkbox(item));
+        grid.addComponentColumn(Checkbox::new);
 
         grid.addItemClickListener(event -> {
             clickMsg.add(event.getItem());
-            columnClickMsg.add(getColumnKeyFromEvent(event));
+            columnClickMsg.add(event.getColumn().getKey());
         });
 
         grid.addItemDoubleClickListener(event -> {
             dblClickMsg
                     .setText(String.valueOf(event.getClientY()));
-            columnDblClickMsg.setText(getColumnKeyFromEvent(event));
+            columnDblClickMsg.setText(event.getColumn().getKey());
         });
 
         grid.setItemDetailsRenderer(new ComponentRenderer<>((SerializableFunction<String, Span>) ItemClickListenerPage::getDetailsComponent));
@@ -67,15 +66,6 @@ public class ItemClickListenerPage extends Div {
         Span result = new Span(s);
         result.setId("details-"+s);
         return result;
-    }
-
-    private static String getColumnKeyFromEvent(ItemClickEvent<?> event) {
-        if (event.getColumn().isPresent()) {
-            return event.getColumn().get().getKey();
-        }
-        else {
-            return "(cannot get clicked column key!)";
-        }
     }
 
 }

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/ItemClickListenerPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/ItemClickListenerPage.java
@@ -50,7 +50,7 @@ public class ItemClickListenerPage extends Div {
             columnKeyMsg.setText(getColumnKeyFromEvent(event));
         });
 
-        add(grid, clickMsg, dblClickMsg);
+        add(grid, clickMsg, dblClickMsg, columnKeyMsg);
     }
 
     private static String getColumnKeyFromEvent(ItemClickEvent<?> event) {

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/ItemClickListenerPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/ItemClickListenerPage.java
@@ -31,8 +31,11 @@ public class ItemClickListenerPage extends Div {
         Div dblClickMsg = new Div();
         dblClickMsg.setId("dblClickMsg");
 
-        Div columnKeyMsg = new Div();
-        columnKeyMsg.setId("columnClickMsg");
+        Div columnClickMsg = new Div();
+        columnClickMsg.setId("columnClickMsg");
+
+        Div columnDblClickMsg = new Div();
+        columnDblClickMsg.setId("columnDblClickMsg");
 
         Grid<String> grid = new Grid<>();
         grid.setItems("foo", "bar");
@@ -41,20 +44,20 @@ public class ItemClickListenerPage extends Div {
 
         grid.addItemClickListener(event -> {
             clickMsg.add(event.getItem());
-            columnKeyMsg.add(getColumnKeyFromEvent(event));
+            columnClickMsg.add(getColumnKeyFromEvent(event));
         });
 
         grid.addItemDoubleClickListener(event -> {
             dblClickMsg
                     .setText(String.valueOf(event.getClientY()));
-            columnKeyMsg.setText(getColumnKeyFromEvent(event));
+            columnDblClickMsg.setText(getColumnKeyFromEvent(event));
         });
 
-        add(grid, clickMsg, dblClickMsg, columnKeyMsg);
+        add(grid, clickMsg, dblClickMsg, columnClickMsg, columnDblClickMsg);
     }
 
     private static String getColumnKeyFromEvent(ItemClickEvent<?> event) {
-        if(event.getColumn().isPresent()) {
+        if (event.getColumn().isPresent()) {
             return event.getColumn().get().getKey();
         }
         else {

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/ItemClickListenerPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/ItemClickListenerPage.java
@@ -19,6 +19,9 @@ import com.vaadin.flow.component.checkbox.Checkbox;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.grid.ItemClickEvent;
 import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.data.renderer.ComponentRenderer;
+import com.vaadin.flow.function.SerializableFunction;
 import com.vaadin.flow.router.Route;
 
 @Route("item-click-listener")
@@ -53,7 +56,17 @@ public class ItemClickListenerPage extends Div {
             columnDblClickMsg.setText(getColumnKeyFromEvent(event));
         });
 
+        grid.setItemDetailsRenderer(new ComponentRenderer<>((SerializableFunction<String, Span>) ItemClickListenerPage::getDetailsComponent));
+        grid.setDetailsVisible("foo", false);
+        grid.setDetailsVisible("bar", true);
+
         add(grid, clickMsg, dblClickMsg, columnClickMsg, columnDblClickMsg);
+    }
+
+    private static Span getDetailsComponent(String s) {
+        Span result = new Span(s);
+        result.setId("details-"+s);
+        return result;
     }
 
     private static String getColumnKeyFromEvent(ItemClickEvent<?> event) {

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/ItemClickListenerIT.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/ItemClickListenerIT.java
@@ -89,15 +89,6 @@ public class ItemClickListenerIT extends AbstractNoW3c {
     }
 
     @Test
-    public void clickComponentInCell_columnNameAvailable() {
-        grid.getCell(0, 0).click();
-        TestBenchElement checkbox = grid.getCell(0, 1).$("vaadin-checkbox")
-                .first();
-        checkbox.click();
-        Assert.assertEquals("Name", getColumnClickMessage());
-    }
-
-    @Test
     public void doubleClickCell_columnNameAvailable() {
         grid.getCell(0, 0).doubleClick();
         Assert.assertEquals("Name", getColumnDoubleClickMessage());

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/ItemClickListenerIT.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/ItemClickListenerIT.java
@@ -27,6 +27,7 @@ import com.vaadin.flow.component.grid.testbench.GridElement;
 import com.vaadin.flow.component.grid.testbench.GridTRElement;
 import com.vaadin.flow.testutil.TestPath;
 import com.vaadin.testbench.TestBenchElement;
+import org.openqa.selenium.WebElement;
 
 @TestPath("item-click-listener")
 public class ItemClickListenerIT extends AbstractNoW3c {
@@ -92,6 +93,16 @@ public class ItemClickListenerIT extends AbstractNoW3c {
     public void doubleClickCell_columnNameAvailable() {
         grid.getCell(0, 0).doubleClick();
         Assert.assertEquals("Name", getColumnDoubleClickMessage());
+    }
+
+    @Test
+    public void clickDetailsCell_noColumnNameAvailable() {
+        waitUntil(driver ->
+                      grid.findElements(By.className("row-details")) != null);
+        WebElement details = findElement(By.id("details-bar"));
+        details.click();
+        Assert.assertEquals("", getColumnClickMessage());
+        Assert.assertEquals("", getColumnDoubleClickMessage());
     }
 
     private String getColumnDoubleClickMessage() {

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/ItemClickListenerIT.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/ItemClickListenerIT.java
@@ -79,6 +79,32 @@ public class ItemClickListenerIT extends AbstractNoW3c {
         checkbox.doubleClick();
         Assert.assertEquals("", getClickMessage());
         Assert.assertEquals("", getDoubleClickMessage());
+        Assert.assertEquals("", getColumnClickMessage());
+    }
+
+    @Test
+    public void clickCell_columnNameAvailable() {
+        grid.getCell(0, 0).click();
+        Assert.assertEquals("Name", getColumnClickMessage());
+    }
+
+    @Test
+    public void clickComponentInCell_columnNameAvailable() {
+        grid.getCell(0, 0).click();
+        TestBenchElement checkbox = grid.getCell(0, 1).$("vaadin-checkbox")
+                .first();
+        checkbox.click();
+        Assert.assertEquals("Name", getColumnClickMessage());
+    }
+
+    @Test
+    public void doubleClickCell_columnNameAvailable() {
+        grid.getCell(0, 0).doubleClick();
+        Assert.assertEquals("Name", getColumnClickMessage());
+    }
+
+    private String getColumnClickMessage() {
+        return findElement(By.id("columnClickMsg")).getText();
     }
 
     private String getClickMessage() {

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/ItemClickListenerIT.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/ItemClickListenerIT.java
@@ -64,6 +64,15 @@ public class ItemClickListenerIT extends AbstractNoW3c {
     }
 
     @Test
+    public void clickCell_clickCheckboxInCell_onlyOneClickEventFired() {
+        grid.getCell(0, 0).click();
+        TestBenchElement checkbox = grid.getCell(0, 1).$("vaadin-checkbox")
+                .first();
+        checkbox.click();
+        Assert.assertEquals("foo", getClickMessage());
+    }
+
+    @Test
     public void doubleClickCheckboxInCell_noEventsFired() {
         TestBenchElement checkbox = grid.getCell(0, 1).$("vaadin-checkbox")
                 .first();
@@ -76,6 +85,15 @@ public class ItemClickListenerIT extends AbstractNoW3c {
     @Test
     public void clickCell_columnNameAvailable() {
         grid.getCell(0, 0).click();
+        Assert.assertEquals("Name", getColumnClickMessage());
+    }
+
+    @Test
+    public void clickComponentInCell_columnNameAvailable() {
+        grid.getCell(0, 0).click();
+        TestBenchElement checkbox = grid.getCell(0, 1).$("vaadin-checkbox")
+                .first();
+        checkbox.click();
         Assert.assertEquals("Name", getColumnClickMessage());
     }
 

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/ItemClickListenerIT.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/ItemClickListenerIT.java
@@ -64,15 +64,6 @@ public class ItemClickListenerIT extends AbstractNoW3c {
     }
 
     @Test
-    public void clickCell_clickCheckboxInCell_onlyOneClickEventFired() {
-        grid.getCell(0, 0).click();
-        TestBenchElement checkbox = grid.getCell(0, 1).$("vaadin-checkbox")
-                .first();
-        checkbox.click();
-        Assert.assertEquals("foo", getClickMessage());
-    }
-
-    @Test
     public void doubleClickCheckboxInCell_noEventsFired() {
         TestBenchElement checkbox = grid.getCell(0, 1).$("vaadin-checkbox")
                 .first();
@@ -89,18 +80,13 @@ public class ItemClickListenerIT extends AbstractNoW3c {
     }
 
     @Test
-    public void clickComponentInCell_columnNameAvailable() {
-        grid.getCell(0, 0).click();
-        TestBenchElement checkbox = grid.getCell(0, 1).$("vaadin-checkbox")
-                .first();
-        checkbox.click();
-        Assert.assertEquals("Name", getColumnClickMessage());
-    }
-
-    @Test
     public void doubleClickCell_columnNameAvailable() {
         grid.getCell(0, 0).doubleClick();
-        Assert.assertEquals("Name", getColumnClickMessage());
+        Assert.assertEquals("Name", getColumnDoubleClickMessage());
+    }
+
+    private String getColumnDoubleClickMessage() {
+        return findElement(By.id("columnDblClickMsg")).getText();
     }
 
     private String getColumnClickMessage() {

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/ItemClickListenerIT.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/ItemClickListenerIT.java
@@ -96,13 +96,15 @@ public class ItemClickListenerIT extends AbstractNoW3c {
     }
 
     @Test
-    public void clickDetailsCell_noColumnNameAvailable() {
+    public void clickDetailsCell_noItemClickEventFired() {
         waitUntil(driver ->
                       grid.findElements(By.className("row-details")) != null);
         WebElement details = findElement(By.id("details-bar"));
         details.click();
         Assert.assertEquals("", getColumnClickMessage());
         Assert.assertEquals("", getColumnDoubleClickMessage());
+        Assert.assertEquals("", getDoubleClickMessage());
+        Assert.assertEquals("", getClickMessage());
     }
 
     private String getColumnDoubleClickMessage() {

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/ItemClickListenerIT.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/ItemClickListenerIT.java
@@ -107,6 +107,18 @@ public class ItemClickListenerIT extends AbstractNoW3c {
         Assert.assertEquals("", getClickMessage());
     }
 
+    @Test
+    public void doubleClickDetailsCell_noItemClickEventFired() {
+        waitUntil(driver ->
+                      grid.findElements(By.className("row-details")) != null);
+        WebElement details = findElement(By.id("details-bar"));
+        ((TestBenchElement)details).doubleClick();
+        Assert.assertEquals("", getColumnClickMessage());
+        Assert.assertEquals("", getColumnDoubleClickMessage());
+        Assert.assertEquals("", getDoubleClickMessage());
+        Assert.assertEquals("", getClickMessage());
+    }
+
     private String getColumnDoubleClickMessage() {
         return findElement(By.id("columnDblClickMsg")).getText();
     }

--- a/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -2661,6 +2661,17 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
     }
 
     /**
+     * Gets a {@link Column} of this grid by its internal id ({@code _flowId}).
+     * @param internalId
+     *            the internal identifier of the column to get
+     * @return the column corresponding to the given column identifier, or {@code null}
+     *         if no column has such an identifier
+     */
+    Column<T> getColumnByInternalId(String internalId) {
+        return idToColumnMap.get(internalId);
+    }
+
+    /**
      * Removes a column with the given column key from the Grid.
      *
      * @param columnKey

--- a/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -2667,7 +2667,7 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
      * @return the column corresponding to the given column identifier, or {@code null}
      *         if no column has such an identifier
      */
-    Column<T> getColumnByInternalId(String internalId) {
+    Column<T> getColumnByFlowId(String internalId) {
         return idToColumnMap.get(internalId);
     }
 

--- a/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -2667,7 +2667,7 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
      * @return the column corresponding to the given column identifier, or {@code null}
      *         if no column has such an identifier
      */
-    Column<T> getColumnByFlowId(String internalId) {
+    Column<T> getColumnByInternalId(String internalId) {
         return idToColumnMap.get(internalId);
     }
 

--- a/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/ItemClickEvent.java
+++ b/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/ItemClickEvent.java
@@ -95,7 +95,7 @@ public class ItemClickEvent<T> extends ClickEvent<Grid<T>> {
         super(source, fromClient, screenX, screenY, clientX, clientY,
                 clickCount, button, ctrlKey, shiftKey, altKey, metaKey);
         item = source.getDataCommunicator().getKeyMapper().get(itemKey);
-        column = source.getColumnByInternalId(flowId);
+        column = source.getColumnByFlowId(flowId);
     }
 
     /**

--- a/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/ItemClickEvent.java
+++ b/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/ItemClickEvent.java
@@ -102,6 +102,56 @@ public class ItemClickEvent<T> extends ClickEvent<Grid<T>> {
     }
 
     /**
+     * Creates a new item click event.
+     *
+     * @param source
+     *            the component that fired the event
+     * @param fromClient
+     *            <code>true</code> if the event was originally fired on the
+     *            client, <code>false</code> if the event originates from
+     *            server-side logic
+     * @param itemKey the item mapper key
+     * @param screenX
+     *            the x coordinate of the click event, relative to the upper
+     *            left corner of the screen, -1 if unknown
+     * @param screenY
+     *            the y coordinate of the click event, relative to the upper
+     *            left corner of the screen, -i if unknown
+     * @param clientX
+     *            the x coordinate of the click event, relative to the upper
+     *            left corner of the browser viewport, -1 if unknown
+     * @param clientY
+     *            the y coordinate of the click event, relative to the upper
+     *            left corner of the browser viewport, -1 if unknown
+     * @param clickCount
+     *            the number of consecutive clicks recently recorded
+     * @param button
+     *            the id of the pressed mouse button
+     * @param ctrlKey
+     *            <code>true</code> if the control key was down when the event
+     *            was fired, <code>false</code> otherwise
+     * @param shiftKey
+     *            <code>true</code> if the shift key was down when the event was
+     *            fired, <code>false</code> otherwise
+     * @param altKey
+     *            <code>true</code> if the alt key was down when the event was
+     *            fired, <code>false</code> otherwise
+     * @param metaKey
+     *            <code>true</code> if the meta key was down when the event was
+     *            fired, <code>false</code> otherwise
+     *
+     * @deprecated Please use the constructor with an extra parameter {@code internalColumnId}
+     */
+    @Deprecated
+    public ItemClickEvent(Grid<T> source, boolean fromClient,
+        String itemKey, int screenX, int screenY, int clientX, int clientY,
+        int clickCount, int button, boolean ctrlKey, boolean shiftKey,
+        boolean altKey, boolean metaKey) {
+        this(source, fromClient, itemKey, "", screenX, screenY, clientX, clientY,
+            clickCount, button, ctrlKey, shiftKey, altKey, metaKey);
+    }
+
+    /**
      * Gets the clicked item.
      *
      * @return the clicked item

--- a/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/ItemClickEvent.java
+++ b/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/ItemClickEvent.java
@@ -81,7 +81,6 @@ public class ItemClickEvent<T> extends ClickEvent<Grid<T>> {
      */
     public ItemClickEvent(Grid<T> source, boolean fromClient,
             @EventData("event.detail.itemKey") String itemKey,
-            @EventData("event.detail.columnKey") String columnKey,
             @EventData("event.detail.flowKey") String flowColumnKey,
             @EventData("event.detail.screenX") int screenX,
             @EventData("event.detail.screenY") int screenY,
@@ -96,18 +95,7 @@ public class ItemClickEvent<T> extends ClickEvent<Grid<T>> {
         super(source, fromClient, screenX, screenY, clientX, clientY,
                 clickCount, button, ctrlKey, shiftKey, altKey, metaKey);
         item = source.getDataCommunicator().getKeyMapper().get(itemKey);
-        // id of column should be set for this to work
-        if(columnKey != null && !columnKey.isEmpty()) {
-            column = source.getColumns().stream().filter(col -> col.getId().isPresent() && columnKey.equals(col.getId().get())).findFirst().orElse(null);
-        }
-        // if id is not set, use internal flow ids
-        else if(flowColumnKey != null && !flowColumnKey.isEmpty() && flowColumnKey.matches("col\\d+")) {
-            column = source.getColumns().get(Integer.parseInt(flowColumnKey.substring(3)));
-        }
-        // otherwise, nothing to report here
-        else {
-            column = null;
-        }
+        column = source.getColumnByInternalId(flowColumnKey);
     }
 
     /**

--- a/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/ItemClickEvent.java
+++ b/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/ItemClickEvent.java
@@ -19,8 +19,6 @@ import com.vaadin.flow.component.ClickEvent;
 import com.vaadin.flow.component.DomEvent;
 import com.vaadin.flow.component.EventData;
 
-import java.util.Optional;
-
 /**
  * Event fired when a Grid item is clicked.
  *
@@ -161,13 +159,12 @@ public class ItemClickEvent<T> extends ClickEvent<Grid<T>> {
     }
 
     /**
-     * Gets the column that was clicked, if available.
-     * @return An optional with column. Optional may be empty if the column could not be figured out or
-     * when the details cell has been clicked (that cell spans through the entire grid and thus there
-     * is no column information).
+     * Gets the column that was clicked.
+     * @return The column that was clicked. It should not be {@code null}, unless somehow the information
+     * about the column has not been passed from the client-side component.
      */
-    public Optional<Grid.Column<T>> getColumn() {
-        return Optional.ofNullable(column);
+    public Grid.Column<T> getColumn() {
+        return column;
     }
 
 }

--- a/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/ItemClickEvent.java
+++ b/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/ItemClickEvent.java
@@ -49,7 +49,7 @@ public class ItemClickEvent<T> extends ClickEvent<Grid<T>> {
      * @param itemKey the item mapper key
      * @param internalColumnId
      *            the internal id of the column associated with
-     *            the click event (if present)
+     *            the click event
      * @param screenX
      *            the x coordinate of the click event, relative to the upper
      *            left corner of the screen, -1 if unknown
@@ -160,8 +160,8 @@ public class ItemClickEvent<T> extends ClickEvent<Grid<T>> {
 
     /**
      * Gets the column that was clicked.
-     * @return The column that was clicked. It should not be {@code null}, unless somehow the information
-     * about the column has not been passed from the client-side component.
+     *
+     * @return the clicked column, not {@code null}
      */
     public Grid.Column<T> getColumn() {
         return column;

--- a/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/ItemClickEvent.java
+++ b/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/ItemClickEvent.java
@@ -81,7 +81,7 @@ public class ItemClickEvent<T> extends ClickEvent<Grid<T>> {
      */
     public ItemClickEvent(Grid<T> source, boolean fromClient,
             @EventData("event.detail.itemKey") String itemKey,
-            @EventData("event.detail.flowKey") String flowColumnKey,
+            @EventData("event.detail.flowId") String flowId,
             @EventData("event.detail.screenX") int screenX,
             @EventData("event.detail.screenY") int screenY,
             @EventData("event.detail.clientX") int clientX,
@@ -95,7 +95,7 @@ public class ItemClickEvent<T> extends ClickEvent<Grid<T>> {
         super(source, fromClient, screenX, screenY, clientX, clientY,
                 clickCount, button, ctrlKey, shiftKey, altKey, metaKey);
         item = source.getDataCommunicator().getKeyMapper().get(itemKey);
-        column = source.getColumnByInternalId(flowColumnKey);
+        column = source.getColumnByInternalId(flowId);
     }
 
     /**
@@ -108,11 +108,10 @@ public class ItemClickEvent<T> extends ClickEvent<Grid<T>> {
     }
 
     /**
-     * Gets the column that was clicked.
-     * For this to really work the column's id must be set. Otherwise internal magic will be used
-     * to figure out which column it is (using column's internal flow identifiers that are then
-     * converted to integer index of the column).
-     * @return An optional with column. Optional may be empty if the column could not be figured out.
+     * Gets the column that was clicked, if available.
+     * @return An optional with column. Optional may be empty if the column could not be figured out or
+     * when the details cell has been clicked (that cell spans through the entire grid and thus there
+     * is no column information).
      */
     public Optional<Grid.Column<T>> getColumn() {
         return Optional.ofNullable(column);

--- a/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/ItemClickEvent.java
+++ b/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/ItemClickEvent.java
@@ -49,6 +49,9 @@ public class ItemClickEvent<T> extends ClickEvent<Grid<T>> {
      *            client, <code>false</code> if the event originates from
      *            server-side logic
      * @param itemKey the item mapper key
+     * @param internalColumnId
+     *            the internal id of the column associated with
+     *            the click event (if present)
      * @param screenX
      *            the x coordinate of the click event, relative to the upper
      *            left corner of the screen, -1 if unknown
@@ -81,7 +84,7 @@ public class ItemClickEvent<T> extends ClickEvent<Grid<T>> {
      */
     public ItemClickEvent(Grid<T> source, boolean fromClient,
             @EventData("event.detail.itemKey") String itemKey,
-            @EventData("event.detail.flowId") String flowId,
+            @EventData("event.detail.internalColumnId") String internalColumnId,
             @EventData("event.detail.screenX") int screenX,
             @EventData("event.detail.screenY") int screenY,
             @EventData("event.detail.clientX") int clientX,
@@ -95,7 +98,7 @@ public class ItemClickEvent<T> extends ClickEvent<Grid<T>> {
         super(source, fromClient, screenX, screenY, clientX, clientY,
                 clickCount, button, ctrlKey, shiftKey, altKey, metaKey);
         item = source.getDataCommunicator().getKeyMapper().get(itemKey);
-        column = source.getColumnByFlowId(flowId);
+        column = source.getColumnByInternalId(internalColumnId);
     }
 
     /**

--- a/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/ItemDoubleClickEvent.java
+++ b/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/ItemDoubleClickEvent.java
@@ -93,4 +93,54 @@ public class ItemDoubleClickEvent<T> extends ItemClickEvent<T> {
                 clickCount, button, ctrlKey, shiftKey, altKey, metaKey);
     }
 
+    /**
+     * Creates a new item double click event.
+     *
+     * @param source
+     *            the component that fired the event
+     * @param fromClient
+     *            <code>true</code> if the event was originally fired on the
+     *            client, <code>false</code> if the event originates from
+     *            server-side logic
+     * @param itemKey the item mapper key
+     * @param screenX
+     *            the x coordinate of the click event, relative to the upper
+     *            left corner of the screen, -1 if unknown
+     * @param screenY
+     *            the y coordinate of the click event, relative to the upper
+     *            left corner of the screen, -i if unknown
+     * @param clientX
+     *            the x coordinate of the click event, relative to the upper
+     *            left corner of the browser viewport, -1 if unknown
+     * @param clientY
+     *            the y coordinate of the click event, relative to the upper
+     *            left corner of the browser viewport, -1 if unknown
+     * @param clickCount
+     *            the number of consecutive clicks recently recorded
+     * @param button
+     *            the id of the pressed mouse button
+     * @param ctrlKey
+     *            <code>true</code> if the control key was down when the event
+     *            was fired, <code>false</code> otherwise
+     * @param shiftKey
+     *            <code>true</code> if the shift key was down when the event was
+     *            fired, <code>false</code> otherwise
+     * @param altKey
+     *            <code>true</code> if the alt key was down when the event was
+     *            fired, <code>false</code> otherwise
+     * @param metaKey
+     *            <code>true</code> if the meta key was down when the event was
+     *            fired, <code>false</code> otherwise
+     *
+     * @deprecated Please use the constructor with an additional parameter {@code internalColumnId}.
+     */
+    @Deprecated
+    public ItemDoubleClickEvent(Grid<T> source, boolean fromClient,
+        String itemKey, int screenX, int screenY, int clientX, int clientY, int clickCount,
+        int button, boolean ctrlKey, boolean shiftKey, boolean altKey, boolean metaKey) {
+        super(source, fromClient, itemKey, screenX, screenY, clientX, clientY,
+            clickCount, button, ctrlKey, shiftKey, altKey, metaKey);
+    }
+
+
 }

--- a/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/ItemDoubleClickEvent.java
+++ b/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/ItemDoubleClickEvent.java
@@ -75,6 +75,8 @@ public class ItemDoubleClickEvent<T> extends ItemClickEvent<T> {
      */
     public ItemDoubleClickEvent(Grid<T> source, boolean fromClient,
             @EventData("event.detail.itemKey") String itemKey,
+            @EventData("event.detail.columnKey") String columnKey,
+            @EventData("event.detail.flowKey") String flowColumnKey,
             @EventData("event.detail.screenX") int screenX,
             @EventData("event.detail.screenY") int screenY,
             @EventData("event.detail.clientX") int clientX,
@@ -85,7 +87,7 @@ public class ItemDoubleClickEvent<T> extends ItemClickEvent<T> {
             @EventData("event.detail.shiftKey") boolean shiftKey,
             @EventData("event.detail.altKey") boolean altKey,
             @EventData("event.detail.metaKey") boolean metaKey) {
-        super(source, fromClient, itemKey, screenX, screenY, clientX, clientY,
+        super(source, fromClient, itemKey, columnKey, flowColumnKey, screenX, screenY, clientX, clientY,
                 clickCount, button, ctrlKey, shiftKey, altKey, metaKey);
     }
 

--- a/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/ItemDoubleClickEvent.java
+++ b/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/ItemDoubleClickEvent.java
@@ -43,6 +43,9 @@ public class ItemDoubleClickEvent<T> extends ItemClickEvent<T> {
      *            client, <code>false</code> if the event originates from
      *            server-side logic
      * @param itemKey the item mapper key
+     * @param internalColumnId
+     *            the internal id of the column associated with
+     *            the click event (if present)
      * @param screenX
      *            the x coordinate of the click event, relative to the upper
      *            left corner of the screen, -1 if unknown
@@ -75,7 +78,7 @@ public class ItemDoubleClickEvent<T> extends ItemClickEvent<T> {
      */
     public ItemDoubleClickEvent(Grid<T> source, boolean fromClient,
             @EventData("event.detail.itemKey") String itemKey,
-            @EventData("event.detail.flowId") String flowId,
+            @EventData("event.detail.internalColumnId") String internalColumnId,
             @EventData("event.detail.screenX") int screenX,
             @EventData("event.detail.screenY") int screenY,
             @EventData("event.detail.clientX") int clientX,
@@ -86,7 +89,7 @@ public class ItemDoubleClickEvent<T> extends ItemClickEvent<T> {
             @EventData("event.detail.shiftKey") boolean shiftKey,
             @EventData("event.detail.altKey") boolean altKey,
             @EventData("event.detail.metaKey") boolean metaKey) {
-        super(source, fromClient, itemKey, flowId, screenX, screenY, clientX, clientY,
+        super(source, fromClient, itemKey, internalColumnId, screenX, screenY, clientX, clientY,
                 clickCount, button, ctrlKey, shiftKey, altKey, metaKey);
     }
 

--- a/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/ItemDoubleClickEvent.java
+++ b/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/ItemDoubleClickEvent.java
@@ -75,7 +75,7 @@ public class ItemDoubleClickEvent<T> extends ItemClickEvent<T> {
      */
     public ItemDoubleClickEvent(Grid<T> source, boolean fromClient,
             @EventData("event.detail.itemKey") String itemKey,
-            @EventData("event.detail.flowKey") String flowColumnKey,
+            @EventData("event.detail.flowId") String flowId,
             @EventData("event.detail.screenX") int screenX,
             @EventData("event.detail.screenY") int screenY,
             @EventData("event.detail.clientX") int clientX,
@@ -86,7 +86,7 @@ public class ItemDoubleClickEvent<T> extends ItemClickEvent<T> {
             @EventData("event.detail.shiftKey") boolean shiftKey,
             @EventData("event.detail.altKey") boolean altKey,
             @EventData("event.detail.metaKey") boolean metaKey) {
-        super(source, fromClient, itemKey, flowColumnKey, screenX, screenY, clientX, clientY,
+        super(source, fromClient, itemKey, flowId, screenX, screenY, clientX, clientY,
                 clickCount, button, ctrlKey, shiftKey, altKey, metaKey);
     }
 

--- a/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/ItemDoubleClickEvent.java
+++ b/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/ItemDoubleClickEvent.java
@@ -45,7 +45,7 @@ public class ItemDoubleClickEvent<T> extends ItemClickEvent<T> {
      * @param itemKey the item mapper key
      * @param internalColumnId
      *            the internal id of the column associated with
-     *            the click event (if present)
+     *            the click event
      * @param screenX
      *            the x coordinate of the click event, relative to the upper
      *            left corner of the screen, -1 if unknown

--- a/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/ItemDoubleClickEvent.java
+++ b/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/ItemDoubleClickEvent.java
@@ -75,7 +75,6 @@ public class ItemDoubleClickEvent<T> extends ItemClickEvent<T> {
      */
     public ItemDoubleClickEvent(Grid<T> source, boolean fromClient,
             @EventData("event.detail.itemKey") String itemKey,
-            @EventData("event.detail.columnKey") String columnKey,
             @EventData("event.detail.flowKey") String flowColumnKey,
             @EventData("event.detail.screenX") int screenX,
             @EventData("event.detail.screenY") int screenY,
@@ -87,7 +86,7 @@ public class ItemDoubleClickEvent<T> extends ItemClickEvent<T> {
             @EventData("event.detail.shiftKey") boolean shiftKey,
             @EventData("event.detail.altKey") boolean altKey,
             @EventData("event.detail.metaKey") boolean metaKey) {
-        super(source, fromClient, itemKey, columnKey, flowColumnKey, screenX, screenY, clientX, clientY,
+        super(source, fromClient, itemKey, flowColumnKey, screenX, screenY, clientX, clientY,
                 clickCount, button, ctrlKey, shiftKey, altKey, metaKey);
     }
 

--- a/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -922,7 +922,6 @@ window.Vaadin.Flow.gridConnector = {
 
     grid.addEventListener('cell-activate', e => {
       grid.$connector.activeItem = e.detail.model.item;
-      e
       setTimeout(() => grid.$connector.activeItem = undefined);
     });
     grid.addEventListener('click', e => _fireClickEvent(e, 'item-click'));
@@ -946,12 +945,10 @@ window.Vaadin.Flow.gridConnector = {
       if (grid.$connector.activeItem) {
         event.itemKey = grid.$connector.activeItem.key;
         const eventContext = grid.getEventContext(event);
-        if (eventContext.column.id) {
-          event.columnKey = eventContext.column.id;
+        // if you have a details-renderer, getEventContext().column is undefined
+        if (eventContext.column) {
+          event.flowKey = eventContext.column._flowId;
         }
-        // flowId should be always set and will be used as
-        // backup when the user forgets about setting column's id
-        event.flowKey = eventContext.column._flowId;
         grid.dispatchEvent(new CustomEvent(eventName,
           { detail: event }));
       }

--- a/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -947,7 +947,7 @@ window.Vaadin.Flow.gridConnector = {
         const eventContext = grid.getEventContext(event);
         // if you have a details-renderer, getEventContext().column is undefined
         if (eventContext.column) {
-          event.flowId = eventContext.column._flowId;
+          event.internalColumnId = eventContext.column._flowId;
         }
         grid.dispatchEvent(new CustomEvent(eventName,
           { detail: event }));

--- a/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -922,6 +922,7 @@ window.Vaadin.Flow.gridConnector = {
 
     grid.addEventListener('cell-activate', e => {
       grid.$connector.activeItem = e.detail.model.item;
+      e
       setTimeout(() => grid.$connector.activeItem = undefined);
     });
     grid.addEventListener('click', e => _fireClickEvent(e, 'item-click'));
@@ -944,6 +945,13 @@ window.Vaadin.Flow.gridConnector = {
     function _fireClickEvent(event, eventName) {
       if (grid.$connector.activeItem) {
         event.itemKey = grid.$connector.activeItem.key;
+        const eventContext = grid.getEventContext(event);
+        if (eventContext.column.id) {
+          event.columnKey = eventContext.column.id;
+        }
+        // flowId should be always set and will be used as
+        // backup when the user forgets about setting column's id
+        event.flowKey = eventContext.column._flowId;
         grid.dispatchEvent(new CustomEvent(eventName,
           { detail: event }));
       }

--- a/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -947,7 +947,7 @@ window.Vaadin.Flow.gridConnector = {
         const eventContext = grid.getEventContext(event);
         // if you have a details-renderer, getEventContext().column is undefined
         if (eventContext.column) {
-          event.flowKey = eventContext.column._flowId;
+          event.flowId = eventContext.column._flowId;
         }
         grid.dispatchEvent(new CustomEvent(eventName,
           { detail: event }));


### PR DESCRIPTION
Added a method to ItemClickListener. It works by passing the id of the column to the event and then discovering the column on the server side.

I used the idea from the workaround by @pekam in https://vaadin.com/forum/thread/17585345/17586229 - but also used internal `flowId` of the column to get it when the user forgets to set the id.

Simple tests included.

Closes #725

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-flow/780)
<!-- Reviewable:end -->
