### PR TITLE
Fix column visual reorder

### DIFF
--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridOrderColumnsPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridOrderColumnsPage.java
@@ -55,6 +55,14 @@ public class GridOrderColumnsPage extends VerticalLayout {
                     grid.setColumnOrder(column3, column1);
                 });
         orderCol31Button.setId("button-31");
-        add(new HorizontalLayout(orderCol123Button, orderCol321Button, orderCol31Button));
+
+        Button visualOrderButton = new Button("Visual 2 1 3",
+                e -> grid.getElement().executeJs(
+                        "this._swapColumnOrders($0, $1)", column1.getElement(),
+                        column2.getElement()));
+        visualOrderButton.setId("button-visual-order");
+
+        add(new HorizontalLayout(orderCol123Button, orderCol321Button,
+                orderCol31Button, visualOrderButton));
     }
 }

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridOrderColumnsPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridOrderColumnsPage.java
@@ -30,24 +30,30 @@ public class GridOrderColumnsPage extends VerticalLayout {
         grid.appendHeaderRow();
         grid.appendFooterRow();
 
-        Grid.Column<Integer> column1 = grid.addColumn(value -> "col1 " + value).setHeader("Col1").setKey("1");
-        Grid.Column<Integer> column2 = grid.addColumn(value -> "col2 " + value).setHeader("Col2").setKey("2");
-        Grid.Column<Integer> column3 = grid.addColumn(value -> "col3 " + value).setHeader("Col3").setKey("3");
+        Grid.Column<Integer> column1 = grid.addColumn(value -> "col1 " + value)
+                .setHeader("Col1").setKey("1");
+        Grid.Column<Integer> column2 = grid.addColumn(value -> "col2 " + value)
+                .setHeader("Col2").setKey("2");
+        Grid.Column<Integer> column3 = grid.addColumn(value -> "col3 " + value)
+                .setHeader("Col3").setKey("3");
 
-        ListDataProvider<Integer> dataProvider = DataProvider.ofItems(1, 2, 3, 4, 5);
+        ListDataProvider<Integer> dataProvider = DataProvider.ofItems(1, 2, 3,
+                4, 5);
         grid.setDataProvider(dataProvider);
         add(grid);
 
-
-        Button orderCol123Button = new Button("Col 1 2 3 ", e -> grid.setColumnOrder(column1, column2, column3));
+        Button orderCol123Button = new Button("Col 1 2 3 ",
+                e -> grid.setColumnOrder(column1, column2, column3));
         orderCol123Button.setId("button-123");
-        Button orderCol321Button = new Button("Col 3 2 1 ", e -> grid.setColumnOrder(column3, column2, column1));
+        Button orderCol321Button = new Button("Col 3 2 1 ",
+                e -> grid.setColumnOrder(column3, column2, column1));
         orderCol321Button.setId("button-321");
 
-        Button orderCol31Button = new Button("order only the columns 3 and 1 ", e -> {
-            grid.removeColumn(column2);
-            grid.setColumnOrder(column3, column1);
-        });
+        Button orderCol31Button = new Button("order only the columns 3 and 1 ",
+                e -> {
+                    grid.removeColumn(column2);
+                    grid.setColumnOrder(column3, column1);
+                });
         orderCol31Button.setId("button-31");
         add(new HorizontalLayout(orderCol123Button, orderCol321Button, orderCol31Button));
     }

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridOrderColumnsIT.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridOrderColumnsIT.java
@@ -64,6 +64,14 @@ public class GridOrderColumnsIT extends AbstractComponentIT {
         assertColumnHeaders("Col1", "Col2", "Col3");
     }
 
+    @Test
+    public void gridVisualOrderReset() {
+        findElement(By.id("button-visual-order")).click();
+        assertColumnHeaders("Col2", "Col1", "Col3");
+        findElement(By.id("button-123")).click();
+        assertColumnHeaders("Col1", "Col2", "Col3");
+    }
+
     private void assertColumnHeaders(String... headers) {
         for (int i = 0; i < headers.length; i++) {
             Assert.assertEquals("Unexpected header for column " + i, headers[i],

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridOrderColumnsIT.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridOrderColumnsIT.java
@@ -65,10 +65,17 @@ public class GridOrderColumnsIT extends AbstractComponentIT {
     }
 
     @Test
-    public void gridVisualOrderReset() {
+    public void clientReorderColumns_serverResetOrder() {
+        // This will visually reorder the columns (the same as dragging the
+        // columns to a different order in UI = doesn't affect the column
+        // elements' DOM order)
         findElement(By.id("button-visual-order")).click();
+        // Make sure the order is as expected
         assertColumnHeaders("Col2", "Col1", "Col3");
+        // Reorder the columns back to the initial order = the order in which
+        // the physical column elements are still in the DOM
         findElement(By.id("button-123")).click();
+        // See that the visual order matches expected
         assertColumnHeaders("Col1", "Col2", "Col3");
     }
 

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridOrderColumnsIT.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridOrderColumnsIT.java
@@ -15,13 +15,14 @@
  */
 package com.vaadin.flow.component.grid.it;
 
-import com.vaadin.flow.component.grid.testbench.GridElement;
-import com.vaadin.flow.testutil.AbstractComponentIT;
-import com.vaadin.flow.testutil.TestPath;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.By;
+
+import com.vaadin.flow.component.grid.testbench.GridElement;
+import com.vaadin.flow.testutil.AbstractComponentIT;
+import com.vaadin.flow.testutil.TestPath;
 
 /**
  * Tests reorder of columns
@@ -65,7 +66,8 @@ public class GridOrderColumnsIT extends AbstractComponentIT {
 
     private void assertColumnHeaders(String... headers) {
         for (int i = 0; i < headers.length; i++) {
-            Assert.assertEquals("Unexpected header for column " + i, headers[i], grid.getHeaderCell(i).getText());
+            Assert.assertEquals("Unexpected header for column " + i, headers[i],
+                    grid.getHeaderCell(i).getText());
         }
     }
 }

--- a/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridColumnOrderHelper.java
+++ b/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridColumnOrderHelper.java
@@ -97,6 +97,11 @@ class GridColumnOrderHelper<T> {
         for (ColumnLayer columnLayer : grid.getColumnLayers()) {
             columnLayer.updateColumnOrder(columnsPreOrder);
         }
+
+        // This will reset all column orders so that the visual column order
+        // will also reflect that in the DOM.
+        grid.getElement()
+                .executeJs("this._updateOrders(this._columnTree, null)");
     }
 
     /**

--- a/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridColumnOrderHelper.java
+++ b/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridColumnOrderHelper.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.component.grid;
 
-import com.vaadin.flow.component.Component;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -29,6 +27,8 @@ import java.util.Objects;
 import java.util.Queue;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import com.vaadin.flow.component.Component;
 
 /**
  * Implements the logic necessary for proper column reordering:
@@ -46,25 +46,29 @@ class GridColumnOrderHelper<T> {
     /**
      * See {@link Grid#setColumnOrder(List)}.
      *
-     * @param columns the new column order, not {@code null}.
+     * @param columns
+     *            the new column order, not {@code null}.
      */
     void setColumnOrder(List<Grid.Column<T>> columns) {
         // first, a couple of sanity checks whether the input list is complete
-        // (contains all Grid columns), doesn't repeat any columns, is not null etc.
+        // (contains all Grid columns), doesn't repeat any columns, is not null
+        // etc.
         Objects.requireNonNull(columns, "columns");
         final Set<Grid.Column<T>> newColumns = new HashSet<>(columns);
         if (newColumns.size() < columns.size()) {
-            throw new IllegalArgumentException("A column is present multiple times in the list of columns: " +
-                    columns.stream().map(Grid.Column::getKey).collect(Collectors.joining(", ")));
+            throw new IllegalArgumentException(
+                    "A column is present multiple times in the list of columns: "
+                            + columns.stream().map(Grid.Column::getKey)
+                                    .collect(Collectors.joining(", ")));
         }
         final List<Grid.Column<T>> currentColumns = grid.getColumns();
         if (newColumns.size() < currentColumns.size()) {
             final String missingColumnKeys = currentColumns.stream()
                     .filter(col -> !newColumns.contains(col))
-                    .map(Grid.Column::getKey)
-                    .collect(Collectors.joining(", "));
-            throw new IllegalArgumentException("The 'columns' list is missing the following columns: "
-                    + missingColumnKeys);
+                    .map(Grid.Column::getKey).collect(Collectors.joining(", "));
+            throw new IllegalArgumentException(
+                    "The 'columns' list is missing the following columns: "
+                            + missingColumnKeys);
         }
         for (Grid.Column<T> column : newColumns) {
             grid.ensureOwner(column);
@@ -72,19 +76,22 @@ class GridColumnOrderHelper<T> {
 
         // sanity test passed. Reorder the columns.
         final List<String> newOrderIDs = columns.stream()
-                .map(Grid.Column::getInternalId)
-                .collect(Collectors.toList());
+                .map(Grid.Column::getInternalId).collect(Collectors.toList());
         final GraphNodeLeafCache nodeLeafCache = new GraphNodeLeafCache();
         // first run a dry run, to check whether the column ordering is possible
         // without actually performing the DOM reorder.
         // This allows us to either fail and leave DOM intact, or succeed
         // and modify the DOM, which guarantees atomicity.
-        reorderColumnsAndConsumeIDs(grid, new IdQueue(newOrderIDs), nodeLeafCache, true);
-        // no exception thrown, the reordering is possible. Run the algorithm again,
+        reorderColumnsAndConsumeIDs(grid, new IdQueue(newOrderIDs),
+                nodeLeafCache, true);
+        // no exception thrown, the reordering is possible. Run the algorithm
+        // again,
         // but this time also reorder the DOM.
-        reorderColumnsAndConsumeIDs(grid, new IdQueue(newOrderIDs), nodeLeafCache, false);
+        reorderColumnsAndConsumeIDs(grid, new IdQueue(newOrderIDs),
+                nodeLeafCache, false);
 
-        // update the new column ordering in the column layers as well, otherwise
+        // update the new column ordering in the column layers as well,
+        // otherwise
         // any future header/footer cell joining would use old ordering.
         final List<ColumnBase<?>> columnsPreOrder = getColumnsPreOrder();
         for (ColumnLayer columnLayer : grid.getColumnLayers()) {
@@ -97,7 +104,7 @@ class GridColumnOrderHelper<T> {
      * order.
      *
      * @return a list of all columns and column groups, ordered with preorder,
-     * never {@code null}.
+     *         never {@code null}.
      */
     private List<ColumnBase<?>> getColumnsPreOrder() {
         return getColumnsPreOrder(grid);
@@ -108,39 +115,44 @@ class GridColumnOrderHelper<T> {
         if (parent instanceof AbstractColumn) {
             list.add((ColumnBase<?>) parent);
         }
-        parent.getChildren()
-                .filter(col -> col instanceof AbstractColumn)
+        parent.getChildren().filter(col -> col instanceof AbstractColumn)
                 .forEach(col -> list.addAll(getColumnsPreOrder(col)));
         return list;
     }
 
     /**
-     * The function walks the expected column ordering and tries
-     * to rearrange its child columns/column-groups so that the DOM order corresponds
-     * to the expected column ordering.
+     * The function walks the expected column ordering and tries to rearrange
+     * its child columns/column-groups so that the DOM order corresponds to the
+     * expected column ordering.
      * <p>
-     * The function recursively invokes itself upon its children, to rearrange the
-     * tree properly.
+     * The function recursively invokes itself upon its children, to rearrange
+     * the tree properly.
      * <p>
      * The tree "dances" until everything is neatly rearranged.
      * <p>
      * The function will never move DOM elements into another parent.
      *
-     * @param column rearrange children of this column. This can only be a {@link Grid}
-     *               or {@link AbstractColumn} instance. Not {@code null}.
-     * @param unconsumedIDs expected column ordering. The IDs are consumed as we
-     *                      visit the column element tree and successfully reorder
-     *                      DOM nodes. Not {@code null}.
-     * @param nodeLeafCache used to quickly find a child column/column-group that
-     *                  contains given leaf column ID as we consume column IDs.
-     * @param dryRun if true then the DOM is not modified.
-     * @throws IllegalArgumentException if the tree can not be rearranged according
-     * to the expected column ordering (e.g. we would have to split a group of columns
-     * apart).
+     * @param column
+     *            rearrange children of this column. This can only be a
+     *            {@link Grid} or {@link AbstractColumn} instance. Not
+     *            {@code null}.
+     * @param unconsumedIDs
+     *            expected column ordering. The IDs are consumed as we visit the
+     *            column element tree and successfully reorder DOM nodes. Not
+     *            {@code null}.
+     * @param nodeLeafCache
+     *            used to quickly find a child column/column-group that contains
+     *            given leaf column ID as we consume column IDs.
+     * @param dryRun
+     *            if true then the DOM is not modified.
+     * @throws IllegalArgumentException
+     *             if the tree can not be rearranged according to the expected
+     *             column ordering (e.g. we would have to split a group of
+     *             columns apart).
      */
-    private void reorderColumnsAndConsumeIDs(Component column, IdQueue unconsumedIDs,
-                                             GraphNodeLeafCache nodeLeafCache,
-                                             boolean dryRun) {
+    private void reorderColumnsAndConsumeIDs(Component column,
+            IdQueue unconsumedIDs, GraphNodeLeafCache nodeLeafCache,
+            boolean dryRun) {
         Objects.requireNonNull(column);
         if (column instanceof Grid.Column) {
             // special case: we're at the leaf of the column hierarchy.
@@ -157,7 +169,8 @@ class GridColumnOrderHelper<T> {
 
         // holds the current immediate child columns.
         final Set<AbstractColumn<?>> childColumns = new HashSet<>();
-        column.getChildren().forEach(it -> childColumns.add((AbstractColumn) it));
+        column.getChildren()
+                .forEach(it -> childColumns.add((AbstractColumn) it));
         // the new order of the children is computed here.
         final List<AbstractColumn<?>> newOrder = new ArrayList<>();
 
@@ -165,23 +178,28 @@ class GridColumnOrderHelper<T> {
             // There are still columns left. Peek on the next ID in the desired
             // order of columns, and try to find a column/column-group for it.
             final String id = unconsumedIDs.element();
-            final AbstractColumn<?> child = nodeLeafCache.findFirstContaining(id, childColumns);
+            final AbstractColumn<?> child = nodeLeafCache
+                    .findFirstContaining(id, childColumns);
             if (child == null) {
                 throw new IllegalArgumentException(dumpColumnHierarchyFromDOM()
                         + ": Cannot reorder columns, at ID: " + unconsumedIDs);
             }
 
-            // found the column. Make sure that its contents are ordered as well.
-            reorderColumnsAndConsumeIDs(child, unconsumedIDs, nodeLeafCache, dryRun);
+            // found the column. Make sure that its contents are ordered as
+            // well.
+            reorderColumnsAndConsumeIDs(child, unconsumedIDs, nodeLeafCache,
+                    dryRun);
             // success - add it to the result list.
             childColumns.remove(child);
             newOrder.add(child);
         }
 
-        // The new node order has been computed successfully. Reorder the elements in DOM.
+        // The new node order has been computed successfully. Reorder the
+        // elements in DOM.
         if (!dryRun) {
             newOrder.forEach(it -> it.getElement().removeFromParent());
-            newOrder.forEach(it -> column.getElement().appendChild(it.getElement()));
+            newOrder.forEach(
+                    it -> column.getElement().appendChild(it.getElement()));
         }
     }
 
@@ -208,8 +226,10 @@ class GridColumnOrderHelper<T> {
 
         /**
          * Peeks at the first ID in the internal queue but doesn't remove it.
+         * 
          * @return the head ID, never {@code null}.
-         * @throws IllegalArgumentException if the queue is empty.
+         * @throws IllegalArgumentException
+         *             if the queue is empty.
          */
         public String element() {
             if (unconsumedIDs.isEmpty()) {
@@ -221,11 +241,14 @@ class GridColumnOrderHelper<T> {
         }
 
         /**
-         * Makes sure the {@link Grid.Column#getInternalId()} matches the {@link #element() head}
-         * of the ID queue. If it does, removes the head of the queue.
-         * @param column the column to match, not {@code null}
-         * @throws IllegalArgumentException if the column ID doesn't match the
-         * head of the queue.
+         * Makes sure the {@link Grid.Column#getInternalId()} matches the
+         * {@link #element() head} of the ID queue. If it does, removes the head
+         * of the queue.
+         * 
+         * @param column
+         *            the column to match, not {@code null}
+         * @throws IllegalArgumentException
+         *             if the column ID doesn't match the head of the queue.
          */
         public void consumeIdFor(Grid.Column<T> column) {
             if (!element().equals(column.getInternalId())) {
@@ -237,40 +260,48 @@ class GridColumnOrderHelper<T> {
     }
 
     /**
-     * Computes and caches a set of leafs attached transitively under a graph node.
-     * The root node is the {@link Grid}, child nodes are instances of {@link AbstractColumn}s,
-     * leaves are {@link Grid.Column}s.
+     * Computes and caches a set of leafs attached transitively under a graph
+     * node. The root node is the {@link Grid}, child nodes are instances of
+     * {@link AbstractColumn}s, leaves are {@link Grid.Column}s.
      */
     private static class GraphNodeLeafCache {
         /**
-         * Maps {@link Grid} or {@link AbstractColumn} to a set of {@link Grid.Column#getInternalId()}s
-         * of leaf {@link Grid.Column}s nested under this node. The sets are unmodifiable.
+         * Maps {@link Grid} or {@link AbstractColumn} to a set of
+         * {@link Grid.Column#getInternalId()}s of leaf {@link Grid.Column}s
+         * nested under this node. The sets are unmodifiable.
          */
         private final Map<Component, Set<String>> nodeLeafsCache = new HashMap<>();
 
         /**
-         * Returns a set of {@link Grid.Column#getInternalId()} of columns hooked
-         * under this {@link Grid} or {@link AbstractColumn}.
+         * Returns a set of {@link Grid.Column#getInternalId()} of columns
+         * hooked under this {@link Grid} or {@link AbstractColumn}.
          *
-         * @param component the component to check, not null, must be {@link Grid}
-         *                  or {@link AbstractColumn}
-         * @return set of {@link Grid.Column#getInternalId()}, never null. Returns
-         * a singleton set for {@link Grid.Column}.
+         * @param component
+         *            the component to check, not null, must be {@link Grid} or
+         *            {@link AbstractColumn}
+         * @return set of {@link Grid.Column#getInternalId()}, never null.
+         *         Returns a singleton set for {@link Grid.Column}.
          */
         public Set<String> getColumnIDs(Component component) {
             Objects.requireNonNull(component);
-            return nodeLeafsCache.computeIfAbsent(component, this::computeNodeLeafs);
+            return nodeLeafsCache.computeIfAbsent(component,
+                    this::computeNodeLeafs);
         }
 
         /**
-         * Finds first column from given list of columns which contains a leaf with
-         * given ID.
-         * @param columnID the desired {@link Grid.Column#getInternalId()}, not null.
-         * @param columns the list of columns to search in, not null.
-         * @return the first column from the {@code columns} parameter containing
-         * leaf with given ID, or null if no such column exists in the list.
+         * Finds first column from given list of columns which contains a leaf
+         * with given ID.
+         * 
+         * @param columnID
+         *            the desired {@link Grid.Column#getInternalId()}, not null.
+         * @param columns
+         *            the list of columns to search in, not null.
+         * @return the first column from the {@code columns} parameter
+         *         containing leaf with given ID, or null if no such column
+         *         exists in the list.
          */
-        public AbstractColumn<?> findFirstContaining(String columnID, Collection<AbstractColumn<?>> columns) {
+        public AbstractColumn<?> findFirstContaining(String columnID,
+                Collection<AbstractColumn<?>> columns) {
             Objects.requireNonNull(columnID);
             for (AbstractColumn<?> column : columns) {
                 if (getColumnIDs(column).contains(columnID)) {
@@ -282,15 +313,19 @@ class GridColumnOrderHelper<T> {
 
         private Set<String> computeNodeLeafs(Component component) {
             if (component instanceof Grid.Column) {
-                return Collections.singleton(((Grid.Column) component).getInternalId());
+                return Collections
+                        .singleton(((Grid.Column) component).getInternalId());
             }
-            if (component instanceof Grid || component instanceof AbstractColumn) {
+            if (component instanceof Grid
+                    || component instanceof AbstractColumn) {
                 return component.getChildren()
                         .filter(col -> col instanceof AbstractColumn)
                         .flatMap(col -> getColumnIDs(col).stream())
                         .collect(Collectors.toSet());
             }
-            throw new IllegalArgumentException("Parameter component: invalid value " + component + ": must be Grid or AbstractColumn");
+            throw new IllegalArgumentException(
+                    "Parameter component: invalid value " + component
+                            + ": must be Grid or AbstractColumn");
         }
     }
 
@@ -301,7 +336,8 @@ class GridColumnOrderHelper<T> {
     private String dumpColumnHierarchyFromDOM(Component component) {
         return component.getChildren().map(child -> {
             if (child instanceof Grid.Column) {
-                return ((Grid.Column) child).getInternalId() + "/" + ((Grid.Column) child).getKey();
+                return ((Grid.Column) child).getInternalId() + "/"
+                        + ((Grid.Column) child).getKey();
             } else {
                 return "(" + dumpColumnHierarchyFromDOM(child) + ")";
             }


### PR DESCRIPTION
Fixes a DX test finding: "If the columns are already physically in correct order in the dom, the column reorder doesn't have any effect even if the columns are visually in different order"

Note that the first commit in this PR is just about autoformatted lines. The meaningful changes are in the second commit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-flow/786)
<!-- Reviewable:end -->
