### PR TITLE
Integrate Grid DnD with Generic Flow DnD

### DIFF
--- a/vaadin-grid-flow-demo/pom.xml
+++ b/vaadin-grid-flow-demo/pom.xml
@@ -24,6 +24,11 @@
             <groupId>com.vaadin</groupId>
             <artifactId>flow-html-components</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-dnd</artifactId>
+            <version>${flow.version}</version>
+        </dependency>
 
         <!-- Component -->
         <dependency>

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/DragAndDropGridGenericPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/DragAndDropGridGenericPage.java
@@ -1,0 +1,149 @@
+package com.vaadin.flow.component.grid.it;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import com.vaadin.flow.component.dnd.DragEndEvent;
+import com.vaadin.flow.component.dnd.DragSource;
+import com.vaadin.flow.component.dnd.DragStartEvent;
+import com.vaadin.flow.component.dnd.DropTarget;
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.grid.dnd.GridDropMode;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.router.Route;
+
+@Route("generic-dnd")
+public class DragAndDropGridGenericPage extends Div {
+
+    private List<String> items = IntStream.range(0, 10).mapToObj(String::valueOf)
+            .collect(Collectors.toList());
+    private Grid<String> grid = new Grid<>();
+    private String draggedCard;
+    private final Div dropbox;
+
+    public DragAndDropGridGenericPage() {
+        grid.addColumn(item -> item).setHeader("Header");
+        grid.setItems(items);
+        grid.setId("grid");
+        grid.setSelectionMode(Grid.SelectionMode.MULTI);
+        grid.setRowsDraggable(true);
+        grid.setDropMode(null);
+
+        dropbox = new Div();
+        dropbox.getStyle().set("display", "flex");
+        dropbox.getStyle().set("border", "1px solid blue");
+        dropbox.setWidth("300px");
+        dropbox.setHeight("300px");
+        DropTarget<Div> dropTarget = DropTarget.create(dropbox);
+        dropTarget.addDropListener(event -> {
+            Optional<Object> dragData = event.getDragData();
+            dragData.filter(object -> object instanceof List).map(object -> ((List<String>) object)).ifPresent(draggedItems -> {
+                draggedItems.stream().forEach(this::addCard);
+                items.removeAll(draggedItems);
+                grid.setItems(items);
+            });
+        });
+
+        add(grid, dropbox);
+
+        addListeners();
+        createControls();
+    }
+
+    private void addListeners() {
+        grid.addDragStartListener(event -> {
+            dropbox.getStyle().set("background-color", "lightgreen");
+            DropTarget.configure(dropbox, true);
+        });
+        grid.addDragEndListener(event -> {
+            dropbox.getStyle().remove("background-color");
+            DropTarget.configure(dropbox, false);
+        });
+
+        grid.addDropListener(event -> {
+            if (draggedCard != null) {
+                items.add(draggedCard);
+                grid.setItems(items);
+                getUI().ifPresent(ui -> dropbox.remove(ui.getActiveDragSourceComponent()));
+            }
+        });
+    }
+
+    private void createControls() {
+
+        NativeButton toggleRowsDraggable = new NativeButton(
+                "Toggle rowsDraggable",
+                e -> grid.setRowsDraggable(!grid.isRowsDraggable()));
+        toggleRowsDraggable.setId("toggle-rows-draggable");
+        add(toggleRowsDraggable);
+
+        Arrays.stream(GridDropMode.values()).forEach(mode -> {
+            NativeButton button = new NativeButton(mode.toString(),
+                    e -> grid.setDropMode(mode));
+            button.setId(mode.toString());
+            add(button);
+        });
+
+        NativeButton setGeneratorsButton = new NativeButton("set generators",
+                e -> {
+                    grid.setDragDataGenerator("text", item -> item + " foo");
+                    grid.setDragDataGenerator("text/html",
+                            item -> "<b>" + item + "</b>");
+                });
+        setGeneratorsButton.setId("set-generators");
+        add(setGeneratorsButton);
+
+        NativeButton setSelectionDragDataButton = new NativeButton(
+                "set selection drag data", e -> {
+            Map<String, String> dragData = new HashMap<>();
+            dragData.put("text", "selection-drag-data");
+            grid.setSelectionDragDetails(-1, dragData);
+        });
+        setSelectionDragDataButton.setId("set-selection-drag-data");
+        add(setSelectionDragDataButton);
+
+        NativeButton setFiltersButton = new NativeButton("set filters", e -> {
+            grid.setDragFilter(item -> "1".equals(item));
+            grid.setDropFilter(item -> "2".equals(item));
+        });
+        setFiltersButton.setId("set-filters");
+        add(setFiltersButton);
+
+        NativeButton multiSelectButton = new NativeButton("multiselect", e -> {
+            grid.select("0");
+            grid.select("1");
+        });
+        multiSelectButton.setId("multiselect");
+        add(multiSelectButton);
+    }
+
+    private void addCard(String card) {
+        Div div = new Div();
+        div.setText(card);
+        div.getStyle().set("border", "1px solid red");
+        div.setHeight("50px");
+        div.setWidth("50px");
+        DragSource<Div> dragSource = DragSource.create(div);
+        dragSource.setDragData(card);
+        dragSource.addDragStartListener(this::onCardDragStart);
+        dragSource.addDragEndListener(this::onCardDragEnd);
+        dropbox.add(div);
+    }
+
+    private void onCardDragEnd(DragEndEvent<Div> divDragEndEvent) {
+        grid.setDropMode(null);
+        draggedCard = null;
+    }
+
+    private void onCardDragStart(DragStartEvent<Div> event) {
+        grid.setDropMode(GridDropMode.BETWEEN);
+        draggedCard = event.getComponent().getText();
+    }
+
+}

--- a/vaadin-grid-flow/pom.xml
+++ b/vaadin-grid-flow/pom.xml
@@ -16,18 +16,6 @@
     <name>Vaadin Grid Flow</name>
 
     <dependencies>
-        <!-- webjars -->
-        <!-- using an npm based webjar because it will contain the version number in the path for the resources -->
-        <dependency>
-            <groupId>org.webjars.npm</groupId>
-            <artifactId>vaadin__vaadin-mobile-drag-drop</artifactId>
-            <version>1.0.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.webjars.npm</groupId>
-            <artifactId>mobile-drag-drop</artifactId>
-            <version>2.3.0-rc.1</version>
-        </dependency>
         <dependency>
             <groupId>org.webjars.bowergithub.vaadin</groupId>
             <artifactId>vaadin-grid</artifactId>
@@ -116,6 +104,12 @@
             <groupId>com.vaadin</groupId>
             <artifactId>flow-data</artifactId>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-dnd</artifactId>
+            <scope>provided</scope>
+            <version>${flow.version}</version>
         </dependency>
 
         <!-- Flow components this depends on -->

--- a/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -38,6 +38,7 @@ import com.vaadin.flow.component.ClientCallable;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.Focusable;
 import com.vaadin.flow.component.HasElement;
 import com.vaadin.flow.component.HasSize;
@@ -50,6 +51,7 @@ import com.vaadin.flow.component.dependency.HtmlImport;
 import com.vaadin.flow.component.dependency.JavaScript;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
+import com.vaadin.flow.component.dnd.internal.DndUtil;
 import com.vaadin.flow.component.grid.GridArrayUpdater.UpdateQueueData;
 import com.vaadin.flow.component.grid.contextmenu.GridContextMenu;
 import com.vaadin.flow.component.grid.dnd.GridDragEndEvent;
@@ -401,9 +403,9 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
 
         /**
          * Gets the width of this column as a CSS-string.
-         * 
+         *
          * @see Grid#addColumnResizeListener(ComponentEventListener)
-         * 
+         *
          * @return the width of this column as a CSS-string
          */
         @Synchronize("column-drag-resize")
@@ -428,9 +430,9 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
 
         /**
          * Gets the flex grow value, by default 1.
-         * 
+         *
          * @see Grid#addColumnResizeListener(ComponentEventListener)
-         * 
+         *
          * @return the flex grow value, by default 1
          */
         @Synchronize("column-drag-resize")
@@ -1324,6 +1326,9 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
                 SelectionMode.SINGLE);
 
         columnLayers.add(new ColumnLayer(this));
+
+        addDragStartListener(this::onDragStart);
+        addDragEndListener(this::onDragEnd);
     }
 
     private void generateUniqueKeyData(T item, JsonObject jsonObject) {
@@ -3211,7 +3216,7 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
         return addListener(ItemClickEvent.class,
                 (ComponentEventListener) Objects.requireNonNull(listener));
     }
-    
+
     /**
      * Adds a column resize listener to this component. Note that the listener
      * will be notified only for user-initiated column resize actions.
@@ -3579,20 +3584,9 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
      * @see GridDropEvent#getDropLocation()
      */
     public void setDropMode(GridDropMode dropMode) {
-        polyfillMobileDragDrop();
+        DndUtil.addMobileDndPolyfillIfNeeded(this);
         getElement().setProperty("dropMode",
                 dropMode == null ? null : dropMode.getClientName());
-    }
-
-    private void polyfillMobileDragDrop() {
-        getElement().getNode().runWhenAttached(ui -> {
-            if (ui.getSession().getBrowser().isIOS()) {
-                ui.getPage().addJavaScript(
-                        "context://webjars/mobile-drag-drop/2.3.0-rc.1/index.min.js");
-                ui.getPage().addJavaScript(
-                        "context://webjars/vaadin__vaadin-mobile-drag-drop/1.0.0/index.min.js");
-            }
-        });
     }
 
     /**
@@ -3616,7 +3610,7 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
      *            {@code false} if not
      */
     public void setRowsDraggable(boolean rowsRraggable) {
-        polyfillMobileDragDrop();
+        DndUtil.addMobileDndPolyfillIfNeeded(this);
         getElement().setProperty("rowsDraggable", rowsRraggable);
     }
 
@@ -3839,11 +3833,11 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
     /**
      * Scrolls to the given row index. Scrolls so that the row is shown at the
      * start of the visible area whenever possible.
-     * 
+     *
      * If the index parameter exceeds current item set size the grid will scroll
      * to the end.
      *
-     * @param index
+     * @param rowIndex
      *            zero based index of the item to scroll to in the current view.
      */
     public void scrollToIndex(int rowIndex) {
@@ -3863,6 +3857,18 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
     public void scrollToEnd() {
         getElement().executeJs("$0.scrollToIndex($0._effectiveSize)",
                 this.getElement());
+    }
+
+    private void onDragStart(GridDragStartEvent<T> event) {
+        ComponentUtil.setData(this,
+                DndUtil.DRAG_SOURCE_DATA_KEY, event.getDraggedItems());
+        getUI().ifPresent(ui -> ui.getInternals().setActiveDragSourceComponent(this));
+    }
+
+    private void onDragEnd(GridDragEndEvent<T> event) {
+        ComponentUtil.setData(this,
+                DndUtil.DRAG_SOURCE_DATA_KEY, null);
+        getUI().ifPresent(ui -> ui.getInternals().setActiveDragSourceComponent(null));
     }
 
 }

--- a/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridDnDTest.java
+++ b/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridDnDTest.java
@@ -1,0 +1,83 @@
+package com.vaadin.flow.component.grid;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.vaadin.flow.component.ComponentUtil;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.dnd.DropEvent;
+import com.vaadin.flow.component.dnd.DropTarget;
+import com.vaadin.flow.component.dnd.EffectAllowed;
+import com.vaadin.flow.component.dnd.internal.DndUtil;
+import com.vaadin.flow.component.grid.dnd.GridDragEndEvent;
+import com.vaadin.flow.component.grid.dnd.GridDragStartEvent;
+import com.vaadin.flow.router.RouterLink;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import elemental.json.Json;
+import elemental.json.JsonArray;
+import elemental.json.JsonObject;
+
+public class GridDnDTest {
+
+    private Grid<String> grid;
+    private UI ui;
+
+    @Before
+    public void setup() {
+        ui = new UI();
+
+        grid = new Grid<String>() {
+            @Override
+            public Optional<UI> getUI() {
+                return Optional.of(ui);
+            }
+        };
+    }
+
+    @Test
+    public void gridDnD_genericDnD_activeDragComponentAndDataSet() {
+        List<String> dragData = Collections.singletonList("2");
+        JsonObject object = Json.createObject();
+        JsonArray array = Json.createArray();
+        JsonObject item = Json.createObject();
+        item.put("key", grid.getDataCommunicator().getKeyMapper().key("2"));
+        array.set(0, item);
+        object.put("draggedItems", array);
+
+        GridDragStartEvent<String> startEvent = new GridDragStartEvent<String>(grid, true, object);
+        ComponentUtil.fireEvent(grid, startEvent);
+
+        Assert.assertEquals("No active drag source set", grid, ui.getActiveDragSourceComponent());
+        Assert.assertEquals("No drag data set", dragData, ComponentUtil.getData(grid, DndUtil.DRAG_SOURCE_DATA_KEY));
+
+        AtomicReference<DropEvent<RouterLink>> eventCapture = new AtomicReference<>();
+        RouterLink routerLink = new RouterLink() {
+            @Override
+            public Optional<UI> getUI() {
+                return Optional.of(ui);
+            }
+        };
+
+        DropTarget.create(routerLink).addDropListener(eventCapture::set);
+
+        ComponentUtil.fireEvent(routerLink, new DropEvent<RouterLink>(routerLink, true, EffectAllowed.ALL.getClientPropertyValue()));
+
+        DropEvent<RouterLink> dropEvent = eventCapture.get();
+
+        Assert.assertEquals("Incorrect drag data", dragData, dropEvent.getDragData().get());
+        Assert.assertEquals("Incorrect drag source", grid, dropEvent.getDragSourceComponent().get());
+
+        ComponentUtil.fireEvent(grid, new GridDragEndEvent<>(grid, true));
+
+        Assert.assertNull("Active drag source not cleared", ui.getActiveDragSourceComponent());
+        Assert.assertNull("Drag data not cleared", ComponentUtil.getData(grid, DndUtil.DRAG_SOURCE_DATA_KEY));
+    }
+
+}


### PR DESCRIPTION
Sets server side drag data and active drag source when grid is dragged.
Uses mobile dnd polyfill from DnDUtil from Flow.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-flow/797)
<!-- Reviewable:end -->
