### PR TITLE
Rename column reorder event's getColumns() to getVisibleColumnOrder()

### DIFF
--- a/vaadin-grid-flow-demo/src/main/java/com/vaadin/flow/component/grid/demo/GridDemo.java
+++ b/vaadin-grid-flow-demo/src/main/java/com/vaadin/flow/component/grid/demo/GridDemo.java
@@ -1326,7 +1326,7 @@ public class GridDemo extends DemoView {
 
         grid.setColumnReorderingAllowed(true);
         grid.addColumnReorderListener(event ->
-                columnOrder.setText(event.getColumns().stream()
+                columnOrder.setText(event.getVisibleColumnOrder().stream()
                         .map(Column::getKey).collect(Collectors.joining(", "))));
 
         // end-source-example

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridTestPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridTestPage.java
@@ -109,6 +109,9 @@ public class GridTestPage extends Div {
             return remove;
         })).setKey("remove");
 
+        grid.addColumn(TemplateRenderer.<Item> of("hidden")).setHeader("hidden")
+                .setVisible(false);
+
         grid.setId("grid-with-component-renderers");
         grid.setWidth("500px");
         grid.setHeight("500px");
@@ -122,16 +125,18 @@ public class GridTestPage extends Div {
             usingFirstList.set(!usingFirstList.get());
         });
         changeList.setId("grid-with-component-renderers-change-list");
-        NativeButton toggleColumnOrdering = new NativeButton("Toggle column ordering", evt -> {
-            grid.setColumnReorderingAllowed(!grid.isColumnReorderingAllowed());
-        });
+        NativeButton toggleColumnOrdering = new NativeButton(
+                "Toggle column ordering", evt -> {
+                    grid.setColumnReorderingAllowed(
+                            !grid.isColumnReorderingAllowed());
+                });
         toggleColumnOrdering.setId("toggle-column-ordering");
 
         Span currentColumnOrdering = new Span();
         currentColumnOrdering.setId("current-column-ordering");
-        grid.addColumnReorderListener(e -> currentColumnOrdering.setText(e.getColumns().stream()
-                .map(Column::getKey)
-                .collect(Collectors.joining(", "))));
+        grid.addColumnReorderListener(e -> currentColumnOrdering
+                .setText(e.getVisibleColumnOrder().stream().map(Column::getKey)
+                        .collect(Collectors.joining(", "))));
 
         add(grid, changeList, toggleColumnOrdering, currentColumnOrdering);
     }

--- a/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/ColumnReorderEvent.java
+++ b/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/ColumnReorderEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2018 Vaadin Ltd.
+ * Copyright 2000-2019 Vaadin Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -15,14 +15,15 @@
  */
 package com.vaadin.flow.component.grid;
 
-import com.vaadin.flow.component.ComponentEvent;
-import com.vaadin.flow.component.DomEvent;
-import com.vaadin.flow.component.EventData;
-import elemental.json.JsonArray;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+
+import com.vaadin.flow.component.ComponentEvent;
+import com.vaadin.flow.component.DomEvent;
+import com.vaadin.flow.component.EventData;
+
+import elemental.json.JsonArray;
 
 /**
  * Event fired when the columns in the Grid are reordered.
@@ -39,9 +40,9 @@ import java.util.List;
 public class ColumnReorderEvent<T> extends ComponentEvent<Grid<T>> {
 
     /**
-     * The new order of the columns. Unmodifiable.
+     * The new order of the visible columns. Unmodifiable.
      */
-    private final List<Grid.Column<T>> columns;
+    private final List<Grid.Column<T>> visibleColumns;
 
     /**
      * Creates a new column reorder event.
@@ -52,13 +53,15 @@ public class ColumnReorderEvent<T> extends ComponentEvent<Grid<T>> {
      *            <code>true</code> if the event was originally fired on the
      *            client, <code>false</code> if the event originates from
      *            server-side logic
-     * @param columnIDs the internal column IDs; automatically translated to
+     * @param visibleColumnIDs
+     *            the internal visible column IDs; automatically translated to
      *            proper Grid Column instances.
      *
      */
     public ColumnReorderEvent(Grid<T> source, boolean fromClient,
-                              @EventData("event.detail.columns.map(col => col._flowId)") JsonArray columnIDs) {
-        this(source, fromClient, getSortedByIds(source.getColumns(), columnIDs));
+            @EventData("event.detail.columns.map(col => col._flowId)") JsonArray visibleColumnIDs) {
+        this(source, fromClient,
+                getSortedByIds(source.getColumns(), visibleColumnIDs));
     }
 
     /**
@@ -70,27 +73,32 @@ public class ColumnReorderEvent<T> extends ComponentEvent<Grid<T>> {
      *            <code>true</code> if the event was originally fired on the
      *            client, <code>false</code> if the event originates from
      *            server-side logic
-     * @param columns the newly ordered Grid columns. Not null, may be empty.
+     * @param visibleColumns
+     *            the newly ordered visible Grid columns. Not null, may be
+     *            empty.
      *
      */
     public ColumnReorderEvent(Grid<T> source, boolean fromClient,
-                              List<Grid.Column<T>> columns) {
+            List<Grid.Column<T>> visibleColumns) {
         super(source, fromClient);
-        this.columns = Collections.unmodifiableList(new ArrayList<>(columns)); // defensive copy
+        this.visibleColumns = Collections
+                .unmodifiableList(new ArrayList<>(visibleColumns)); // defensive
+                                                                    // copy
     }
 
     /**
-     * Gets the new order of the columns.
+     * Gets the new order of the visible columns.
      *
-     * @return the list of columns, not null, unmodifiable.
+     * @return the list of visible columns, not null, unmodifiable.
      */
-    public List<Grid.Column<T>> getColumns() {
-        return columns;
+    public List<Grid.Column<T>> getVisibleColumnOrder() {
+        return visibleColumns;
     }
 
-    private static <T> List<Grid.Column<T>> getSortedByIds(List<Grid.Column<T>> currentColumns,
-                                                           JsonArray columnIDs) {
-        final List<Grid.Column<T>> columns = new ArrayList<>(currentColumns.size());
+    private static <T> List<Grid.Column<T>> getSortedByIds(
+            List<Grid.Column<T>> currentColumns, JsonArray columnIDs) {
+        final List<Grid.Column<T>> columns = new ArrayList<>(
+                currentColumns.size());
         for (int i = 0; i < columnIDs.length(); i++) {
             final String columnID = columnIDs.getString(i);
             columns.add(findByColumnId(currentColumns, columnID));
@@ -98,10 +106,10 @@ public class ColumnReorderEvent<T> extends ComponentEvent<Grid<T>> {
         return columns;
     }
 
-    private static <T> Grid.Column<T> findByColumnId(List<Grid.Column<T>> columns, String id) {
-        return columns.stream()
-                .filter(it -> id.equals(it.getInternalId()))
-                .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("No column with ID " + id));
+    private static <T> Grid.Column<T> findByColumnId(
+            List<Grid.Column<T>> columns, String id) {
+        return columns.stream().filter(it -> id.equals(it.getInternalId()))
+                .findFirst().orElseThrow(() -> new IllegalArgumentException(
+                        "No column with ID " + id));
     }
 }

--- a/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridColumnOrderTest.java
+++ b/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridColumnOrderTest.java
@@ -100,7 +100,7 @@ public class GridColumnOrderTest {
         grid.addColumnReorderListener(event::set);
         grid.setColumnOrder(fourthColumn, thirdColumn, secondColumn, firstColumn);
         assertNotNull(event.get());
-        assertArrayEquals(new Object[]{fourthColumn, thirdColumn, secondColumn, firstColumn}, event.get().getColumns().toArray());
+        assertArrayEquals(new Object[]{fourthColumn, thirdColumn, secondColumn, firstColumn}, event.get().getVisibleColumnOrder().toArray());
         assertFalse(event.get().isFromClient());
         assertSame(grid, event.get().getSource());
     }


### PR DESCRIPTION
Fixes #804 

Also added a "hidden" column to an existing column reordering event test case to make sure hidden columns are excluded from the list obtained from getVisibleColumnOrder() in the future also.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-flow/806)
<!-- Reviewable:end -->
