### PR TITLE
Send null to client instead of {key:"null"} object

### DIFF
--- a/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -2549,7 +2549,7 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
         }
         JsonArray jsonArray = Json.createArray();
         for (T item : items) {
-            JsonObject jsonObject = generateJsonForSelection(item);
+            JsonObject jsonObject = item != null ? generateJsonForSelection(item) : null;
             jsonArray.set(jsonArray.length(), jsonObject);
         }
         getElement().callJsFunction("$connector." + function, jsonArray, false);

--- a/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -168,7 +168,8 @@ window.Vaadin.Flow.gridConnector = {
             grid.$server.select(item.key);
           }
         }
-        if (!userOriginated && selectionMode === 'SINGLE' && (!grid.activeItem || !item || item.key != grid.activeItem.key)) {
+        const isSelectedItemDifferentOrNull = !grid.activeItem || !item || item.key != grid.activeItem.key;
+        if (!userOriginated && selectionMode === 'SINGLE' && isSelectedItemDifferentOrNull) {
           grid.activeItem = item;
           grid.$connector.activeItem = item;
         }

--- a/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -161,11 +161,14 @@ window.Vaadin.Flow.gridConnector = {
 
       grid.selectedItems = grid.selectedItems.concat(items);
       items.forEach(item => {
-        selectedKeys[item.key] = item;
-        if (userOriginated) {
-          item.selected = true;
-          grid.$server.select(item.key);
-        } else if (selectionMode === 'SINGLE' && (!grid.activeItem || item.key != grid.activeItem.key)) {
+        if (item) {
+          selectedKeys[item.key] = item;
+          if (userOriginated) {
+            item.selected = true;
+            grid.$server.select(item.key);
+          }
+        }
+        if (!userOriginated && selectionMode === 'SINGLE' && (!grid.activeItem || !item || item.key != grid.activeItem.key)) {
           grid.activeItem = item;
           grid.$connector.activeItem = item;
         }
@@ -183,15 +186,17 @@ window.Vaadin.Flow.gridConnector = {
         const itemToDeselect = items.shift();
         for (let i = 0; i < updatedSelectedItems.length; i++) {
           const selectedItem = updatedSelectedItems[i];
-          if (itemToDeselect.key === selectedItem.key) {
+          if (itemToDeselect && itemToDeselect.key === selectedItem.key) {
             updatedSelectedItems.splice(i, 1);
             break;
           }
         }
-        delete selectedKeys[itemToDeselect.key];
-        if (userOriginated) {
-          delete itemToDeselect.selected;
-          grid.$server.deselect(itemToDeselect.key);
+        if (itemToDeselect) {
+          delete selectedKeys[itemToDeselect.key];
+          if (userOriginated) {
+            delete itemToDeselect.selected;
+            grid.$server.deselect(itemToDeselect.key);
+          }
         }
       }
       grid.selectedItems = updatedSelectedItems;
@@ -879,7 +884,7 @@ window.Vaadin.Flow.gridConnector = {
     }
 
     grid.$connector.deselectAllowed = true;
-    
+
     // TODO: should be removed once https://github.com/vaadin/vaadin-grid/issues/1471 gets implemented
     grid.$connector.setVerticalScrollingEnabled = function(enabled) {
       // There are two scollable containers in grid so apply the changes for both


### PR DESCRIPTION
`Grid#callSelectionFunctionForItems` prepares items as a json array before sending it to connector. It creates an array of `{key: KEY}` object. When `Grid#deselectAll` is called, the former method creates an object `{key:"null"}` and that object ends up being the activeItem on client. What this changes does it to send `null` to be set on client instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-flow/815)
<!-- Reviewable:end -->
