### PR TITLE
Fix setColumnOrder if 2 header rows

### DIFF
--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridOrderColumnsPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridOrderColumnsPage.java
@@ -27,8 +27,6 @@ import com.vaadin.flow.router.Route;
 public class GridOrderColumnsPage extends VerticalLayout {
     public GridOrderColumnsPage() {
         Grid<Integer> grid = new Grid<>();
-        grid.appendHeaderRow();
-        grid.appendFooterRow();
 
         Grid.Column<Integer> column1 = grid.addColumn(value -> "col1 " + value)
                 .setHeader("Col1").setKey("1");
@@ -38,6 +36,9 @@ public class GridOrderColumnsPage extends VerticalLayout {
                 .setHeader("Col3").setKey("3");
         Grid.Column<Integer> column4 = grid.addColumn(value -> "col4 " + value)
                 .setHeader("Col4").setKey("4");
+
+        grid.appendHeaderRow();
+        grid.appendFooterRow();
 
         // Adding invisible column to make sure it's not affecting ordering
         // of the visible columns

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridOrderColumnsPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridOrderColumnsPage.java
@@ -27,6 +27,8 @@ import com.vaadin.flow.router.Route;
 public class GridOrderColumnsPage extends VerticalLayout {
     public GridOrderColumnsPage() {
         Grid<Integer> grid = new Grid<>();
+        grid.appendHeaderRow();
+        grid.appendFooterRow();
 
         Grid.Column<Integer> column1 = grid.addColumn(value -> "col1 " + value)
                 .setHeader("Col1").setKey("1");
@@ -36,9 +38,6 @@ public class GridOrderColumnsPage extends VerticalLayout {
                 .setHeader("Col3").setKey("3");
         Grid.Column<Integer> column4 = grid.addColumn(value -> "col4 " + value)
                 .setHeader("Col4").setKey("4");
-
-        grid.appendHeaderRow();
-        grid.appendFooterRow();
 
         // Adding invisible column to make sure it's not affecting ordering
         // of the visible columns

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridOrderColumnsPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridOrderColumnsPage.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.treegrid.it;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.grid.Grid.SelectionMode;
+import com.vaadin.flow.component.grid.HeaderRow;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.treegrid.TreeGrid;
+import com.vaadin.flow.data.bean.HierarchicalTestBean;
+import com.vaadin.flow.data.provider.hierarchy.TreeData;
+import com.vaadin.flow.router.Route;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Route(TreeGridOrderColumnsPage.VIEW)
+public class TreeGridOrderColumnsPage extends Div {
+
+    public static final String VIEW = "treegrid-order-columns";
+    public static final String COL1_NAME = "Col1";
+    public static final String COL2_NAME = "Col2";
+    public static final String COL3_NAME = "Col3";
+    public static final String HEADER2_PREFIX = "Header 2 ";
+    public static final String HEADER3_PREFIX = "Header 3 ";
+
+    private TreeGrid<HierarchicalTestBean> treeGrid;
+
+    public TreeGridOrderColumnsPage() {
+        initializeDataProviders();
+        treeGrid = new TreeGrid<>(HierarchicalTestBean.class);
+        treeGrid.setColumnReorderingAllowed(true);
+        treeGrid.setWidth("100%");
+        treeGrid.setSelectionMode(SelectionMode.MULTI);
+        treeGrid.setColumns("id", HierarchicalTestBean::toString,
+                Arrays.asList("id", "depth", "index"));
+        treeGrid.setDataProvider(new LazyHierarchicalDataProvider(3, 2));
+
+        treeGrid.setId("testComponent");
+
+        Grid.Column<HierarchicalTestBean> column1 = treeGrid.getColumnByKey("id");
+        column1.setHeader(COL1_NAME);
+        Grid.Column<HierarchicalTestBean> column2 = treeGrid.getColumnByKey("depth");
+        column2.setHeader(COL2_NAME);
+        Grid.Column<HierarchicalTestBean> column3 = treeGrid.getColumnByKey("index");
+        column3.setHeader(COL3_NAME);
+
+        HeaderRow row1 = treeGrid.appendHeaderRow();
+        row1.getCell(column1).setText(HEADER2_PREFIX + COL1_NAME);
+        row1.getCell(column2).setText(HEADER2_PREFIX + COL2_NAME);
+        row1.getCell(column3).setText(HEADER2_PREFIX + COL3_NAME);
+        HeaderRow row2 = treeGrid.appendHeaderRow();
+        row2.getCell(column1).setText(HEADER3_PREFIX + COL1_NAME);
+        row2.getCell(column2).setText(HEADER3_PREFIX + COL2_NAME);
+        row2.getCell(column3).setText(HEADER3_PREFIX + COL3_NAME);
+        add(treeGrid);
+
+        Button orderCol123Button = new Button("Col 1 2 3 ",
+                e -> treeGrid.setColumnOrder(column1, column2, column3));
+        orderCol123Button.setId("button-123");
+        Button orderCol321Button = new Button("Col 3 2 1 ",
+                e -> treeGrid.setColumnOrder(column3, column2, column1));
+        orderCol321Button.setId("button-321");
+
+        add(orderCol123Button, orderCol321Button);
+    }
+
+    private void initializeDataProviders() {
+        TreeData<HierarchicalTestBean> data = new TreeData<>();
+
+        List<Integer> ints = Arrays.asList(0, 1, 2);
+
+        ints.stream().forEach(index -> {
+            HierarchicalTestBean bean = new HierarchicalTestBean(null, 0,
+                    index);
+            data.addItem(null, bean);
+            ints.stream().forEach(childIndex -> {
+                HierarchicalTestBean childBean = new HierarchicalTestBean(
+                        bean.getId(), 1, childIndex);
+                data.addItem(bean, childBean);
+                ints.stream()
+                        .forEach(grandChildIndex -> data.addItem(childBean,
+                                new HierarchicalTestBean(childBean.getId(), 2,
+                                        grandChildIndex)));
+            });
+        });
+    }
+
+}

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridOrderColumnsIT.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridOrderColumnsIT.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2000-2019 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.treegrid.it;
+
+import com.vaadin.flow.component.grid.testbench.TreeGridElement;
+import com.vaadin.flow.testutil.AbstractComponentIT;
+import com.vaadin.flow.testutil.TestPath;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+/**
+ * Tests reorder of columns
+ */
+@TestPath(TreeGridOrderColumnsPage.VIEW)
+public class TreeGridOrderColumnsIT extends AbstractComponentIT {
+
+    private TreeGridElement treeGrid;
+
+    @Before
+    public void init() {
+        open();
+        treeGrid = $(TreeGridElement.class).first();
+    }
+
+    @Test
+    public void gridOrder_123() {
+        findElement(By.id("button-123")).click();
+        assertColumnHeaders(TreeGridOrderColumnsPage.COL1_NAME,
+                TreeGridOrderColumnsPage.COL2_NAME,
+                TreeGridOrderColumnsPage.COL3_NAME);
+    }
+
+    @Test
+    public void gridOrder_321() {
+        findElement(By.id("button-321")).click();
+        assertColumnHeaders(TreeGridOrderColumnsPage.COL3_NAME,
+                TreeGridOrderColumnsPage.COL2_NAME,
+                TreeGridOrderColumnsPage.COL1_NAME);
+    }
+
+    @Test
+    public void gridOrder_321_123() {
+        findElement(By.id("button-321")).click();
+        assertColumnHeaders(TreeGridOrderColumnsPage.COL3_NAME,
+                TreeGridOrderColumnsPage.COL2_NAME,
+                TreeGridOrderColumnsPage.COL1_NAME);
+        findElement(By.id("button-123")).click();
+        assertColumnHeaders(TreeGridOrderColumnsPage.COL1_NAME,
+                TreeGridOrderColumnsPage.COL2_NAME,
+                TreeGridOrderColumnsPage.COL3_NAME);
+    }
+
+    private void assertColumnHeaders(String... headers) {
+        for (int i = 0; i < headers.length; i++) {
+            // columnIndex 0 is multi select in the grid
+            int columnIndex = i + 1;
+            Assert.assertEquals(
+                    "Unexpected header for column " + i, headers[i],
+                    treeGrid.getHeaderCellContent(0, columnIndex).getText());
+            Assert.assertEquals(
+                    "Unexpected header for column " + i,
+                    TreeGridOrderColumnsPage.HEADER2_PREFIX + headers[i],
+                    treeGrid.getHeaderCellContent(1, columnIndex).getText());
+            Assert.assertEquals(
+                    "Unexpected header for column " + i,
+                    TreeGridOrderColumnsPage.HEADER3_PREFIX + headers[i],
+                    treeGrid.getHeaderCellContent(2, columnIndex).getText());
+        }
+    }
+}

--- a/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridColumnOrderHelper.java
+++ b/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridColumnOrderHelper.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Queue;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import com.vaadin.flow.component.Component;

--- a/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridColumnOrderHelper.java
+++ b/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridColumnOrderHelper.java
@@ -276,7 +276,7 @@ class GridColumnOrderHelper<T> {
          * {@link Grid.Column#getInternalId()}s of leaf {@link Grid.Column}s
          * nested under this node. The sets are unmodifiable.
          */
-        private final Map<Component, Set<String>> nodeLeafsCache = new ConcurrentHashMap<>();
+        private final Map<Component, Set<String>> nodeLeafsCache = new HashMap<>();
 
         /**
          * Returns a set of {@link Grid.Column#getInternalId()} of columns
@@ -288,10 +288,17 @@ class GridColumnOrderHelper<T> {
          * @return set of {@link Grid.Column#getInternalId()}, never null.
          *         Returns a singleton set for {@link Grid.Column}.
          */
-        public Set<String> getColumnIDs(Component component) {
+        private Set<String> getColumnIDs(Component component) {
             Objects.requireNonNull(component);
-            return nodeLeafsCache.computeIfAbsent(component,
-                    this::computeNodeLeafs);
+            if (nodeLeafsCache.get(component) == null) {
+                Set<String> computeNodeLeafs = computeNodeLeafs(component);
+                if (computeNodeLeafs != null) {
+                    nodeLeafsCache.put(component, computeNodeLeafs);
+                } else {
+                    return new HashSet<>();
+                }
+            }
+            return nodeLeafsCache.get(component);
         }
 
         /**

--- a/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridColumnOrderHelper.java
+++ b/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridColumnOrderHelper.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import com.vaadin.flow.component.Component;
@@ -275,7 +276,7 @@ class GridColumnOrderHelper<T> {
          * {@link Grid.Column#getInternalId()}s of leaf {@link Grid.Column}s
          * nested under this node. The sets are unmodifiable.
          */
-        private final Map<Component, Set<String>> nodeLeafsCache = new HashMap<>();
+        private final Map<Component, Set<String>> nodeLeafsCache = new ConcurrentHashMap<>();
 
         /**
          * Returns a set of {@link Grid.Column#getInternalId()} of columns

--- a/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridColumnOrderTest.java
+++ b/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridColumnOrderTest.java
@@ -85,6 +85,56 @@ public class GridColumnOrderTest {
     }
 
     @Test
+    public void setColumnOrder_simpleCaseWithTenHeadersAndFooters() {
+        grid.appendHeaderRow();
+        grid.appendHeaderRow();
+        grid.appendHeaderRow();
+        grid.appendHeaderRow();
+        grid.appendHeaderRow();
+        grid.appendHeaderRow();
+        grid.appendHeaderRow();
+        grid.appendHeaderRow();
+        grid.appendHeaderRow();
+        grid.appendHeaderRow();
+        grid.appendFooterRow();
+        grid.appendFooterRow();
+        grid.appendFooterRow();
+        grid.appendFooterRow();
+        grid.appendFooterRow();
+        grid.appendFooterRow();
+        grid.appendFooterRow();
+        grid.appendFooterRow();
+        grid.appendFooterRow();
+        grid.appendFooterRow();
+        // verify that the Grid wrapped <grid-column> elements in <grid-column-group> elements
+        assertEquals(4, grid.getChildren().filter(it -> it instanceof ColumnGroup).count());
+        grid.setColumnOrder(fourthColumn, thirdColumn, secondColumn, firstColumn);
+        assertArrayEquals(new Object[]{fourthColumn, thirdColumn, secondColumn, firstColumn}, grid.getColumns().toArray());
+    }
+
+    @Test
+    public void setColumnOrder_headerFooterMultiSelect() {
+        grid.setSelectionMode(Grid.SelectionMode.MULTI);
+        grid.appendHeaderRow();
+        grid.appendHeaderRow();
+        // verify that the Grid wrapped <grid-column> elements in <grid-column-group> elements
+        assertEquals(4, grid.getChildren().filter(it -> it instanceof ColumnGroup).count());
+        grid.setColumnOrder(fourthColumn, thirdColumn, secondColumn, firstColumn);
+        assertArrayEquals(new Object[]{fourthColumn, thirdColumn, secondColumn, firstColumn}, grid.getColumns().toArray());
+    }
+
+    @Test
+    public void setColumnOrder_headerFooterSingleSelect() {
+        grid.setSelectionMode(Grid.SelectionMode.SINGLE);
+        grid.appendHeaderRow();
+        grid.appendHeaderRow();
+        // verify that the Grid wrapped <grid-column> elements in <grid-column-group> elements
+        assertEquals(4, grid.getChildren().filter(it -> it instanceof ColumnGroup).count());
+        grid.setColumnOrder(fourthColumn, thirdColumn, secondColumn, firstColumn);
+        assertArrayEquals(new Object[]{fourthColumn, thirdColumn, secondColumn, firstColumn}, grid.getColumns().toArray());
+    }
+
+    @Test
     public void setColumnOrder_simpleCaseWithFooter() {
         grid.appendFooterRow();
         grid.appendFooterRow();


### PR DESCRIPTION
Change the HashMap to ConcurrentHashMap.
Change the test case to throw an exception if Map is a HashMap

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-flow/828)
<!-- Reviewable:end -->
