### PR TITLE
Propagate enabled state to header and footer components

### DIFF
--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/DisabledGridPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/DisabledGridPage.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.component.grid.it;
 
-import java.util.Arrays;
-
 import com.vaadin.flow.component.checkbox.Checkbox;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.html.Div;
@@ -24,6 +22,8 @@ import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.data.renderer.NativeButtonRenderer;
 import com.vaadin.flow.function.ValueProvider;
 import com.vaadin.flow.router.Route;
+
+import java.util.Arrays;
 
 @Route("disabled-grid")
 public class DisabledGridPage extends Div {
@@ -47,6 +47,11 @@ public class DisabledGridPage extends Div {
                 event -> reportError());
         headerButton.setId("header-button");
         grid.prependHeaderRow().getCells().get(0).setComponent(headerButton);
+
+        NativeButton footerButton = new NativeButton("Button in footer",
+                event -> reportError());
+        footerButton.setId("footer-button");
+        grid.prependFooterRow().getCells().get(0).setComponent(footerButton);
 
         NativeButton toggleEnabled = new NativeButton("Toggle enabled",
                 event -> grid.setEnabled(!grid.isEnabled()));

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/DisabledGridIT.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/DisabledGridIT.java
@@ -97,7 +97,6 @@ public class DisabledGridIT extends AbstractComponentIT {
         assertEmptyMessage(message);
     }
 
-    @Ignore // https://github.com/vaadin/flow/issues/3998
     @Test
     public void gridIsDisabled_componentsInHeaderHaveDisabledAttribute() {
         open();
@@ -113,6 +112,23 @@ public class DisabledGridIT extends AbstractComponentIT {
         Assert.assertFalse(
                 "Button in the header should have 'disabled' attribute",
                 headerButton.isEnabled());
+    }
+
+    @Test
+    public void gridIsDisabled_componentsInFooterHaveDisabledAttribute() {
+        open();
+        GridElement grid = $(GridElement.class).id("grid");
+        TestBenchElement footerButton = grid
+                .findElement(By.id("footer-button"));
+
+        Assert.assertTrue("Button in the footer should be enabled",
+                footerButton.isEnabled());
+
+        disableGrid();
+
+        Assert.assertFalse(
+                "Button in the footer should have 'disabled' attribute",
+                footerButton.isEnabled());
     }
 
     @Test


### PR DESCRIPTION
Fixes #814 
The root of the issue is coming from https://github.com/vaadin/flow/issues/3998.

It's working with the components inside the columns, because on `EnabledStateChanged` it regenerates the components in the cells with `DataCommunicator`. It's not affecting header and footer components, so requires a temporary solution with saving the references to the components and propagating `enabled` state to those.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid-flow/832)
<!-- Reviewable:end -->
