### PR TITLE
Replace Lambda with inline SerializableComparator

### DIFF
--- a/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -544,6 +544,10 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
          * <p>
          * <strong>Note:</strong> calling this method automatically sets the
          * column as sortable with {@link #setSortable(boolean)}.
+         * <p>
+         * <strong>Note:</strong> Comparator is not serializable. If you need
+         * to write serializable implementation, use inlined class of 
+         * {@link SerializableComparator} instead of Lambda expression.
          *
          * @param comparator
          *            the comparator to use when sorting data in this column

--- a/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -546,7 +546,7 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
          * column as sortable with {@link #setSortable(boolean)}.
          * <p>
          * <strong>Note:</strong> Comparator is not serializable. If you need
-         * to write serializable implementation, use inlined class of 
+         * to write serializable implementation, use inlined class of
          * {@link SerializableComparator} instead of Lambda expression.
          *
          * @param comparator

--- a/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
+++ b/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
@@ -305,8 +305,13 @@ public class TreeGrid<T> extends Grid<T>
                 .withProperty("name",
                         value -> String.valueOf(valueProvider.apply(value))));
         column.setComparator(
-                ((a, b) -> compareMaybeComparables(valueProvider.apply(a),
-                        valueProvider.apply(b))));
+                new SerializableComparator<T>() {
+                    @Override
+                    public int compare(T a, T b) {
+                    return compareMaybeComparables(valueProvider.apply(a),
+                            valueProvider.apply(b));
+                    }
+                });
 
         return column;
     }

--- a/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
+++ b/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
@@ -46,6 +46,7 @@ import com.vaadin.flow.data.renderer.TemplateRenderer;
 import com.vaadin.flow.dom.DisabledUpdateMode;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.SerializableBiFunction;
+import com.vaadin.flow.function.SerializableComparator;
 import com.vaadin.flow.function.SerializablePredicate;
 import com.vaadin.flow.function.SerializableSupplier;
 import com.vaadin.flow.function.ValueProvider;


### PR DESCRIPTION
Since setComparator() uses Comparator as type parameter, Lambda will not be serializable. Inline SerlializableComparator class should be used instead. It would be even better to fix setComparator type parameter to be SerializableCompator, but there are additional problems to be solved before it can be made, as seen in https://github.com/vaadin/vaadin-grid-flow/pull/840

Fixes: https://github.com/vaadin/vaadin-grid-flow/issues/839