### PR TITLE
Fix connector tryCatchWrapper definition

### DIFF
--- a/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -9,7 +9,7 @@
   window.Vaadin.Flow.Legacy = window.Vaadin.Flow.Legacy || {};
 
   window.Vaadin.Flow.gridConnector = {
-    initLazy: tryCatchWrapper(function(grid) {
+    initLazy: grid => tryCatchWrapper(function(grid) {
       // Check whether the connector was already initialized for the grid
       if (grid.$connector){
         return;
@@ -1019,6 +1019,6 @@
           });
         }
       }));
-    })
+    })(grid)
   }
 })();


### PR DESCRIPTION
Connected to https://github.com/vaadin/vaadin-combo-box-flow/issues/313
Make the `Flow.tryCatchWrapper` called lazily.