### PR TITLE
Fix running tests locally

### DIFF
--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/AbstractNoW3c.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/AbstractNoW3c.java
@@ -47,15 +47,16 @@ public class AbstractNoW3c extends AbstractComponentIT {
     }
 
     public static WebDriver createChromeDriverWithoutW3c(
-        Optional<LocalExecution> localExecution, DesiredCapabilities capabilities, String hubURL) throws Exception {
+        Optional<LocalExecution> localExecution,
+        DesiredCapabilities capabilities, String hubURL) throws Exception {
 
         final ChromeOptions options = createChromeOptions();
         options.merge(capabilities);
 
-        if(!localExecution.isPresent()) {
-            return TestBench.createDriver(
-                new RemoteWebDriver(new URL(hubURL), options));
-        }else if(localExecution.get().value() == Browser.CHROME) {
+        if (!localExecution.isPresent()) {
+            return TestBench
+                .createDriver(new RemoteWebDriver(new URL(hubURL), options));
+        } else if (localExecution.get().value() == Browser.CHROME) {
             return TestBench.createDriver(new ChromeDriver(options));
         }
         return null;

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/AbstractNoW3c.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/AbstractNoW3c.java
@@ -16,13 +16,17 @@
 package com.vaadin.flow.component;
 
 import java.net.URL;
+import java.util.Optional;
 
+import com.vaadin.flow.testutil.LocalExecution;
+import com.vaadin.testbench.parallel.Browser;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.RemoteWebDriver;
 
 import com.vaadin.flow.testutil.AbstractComponentIT;
-import com.vaadin.testbench.Parameters;
 import com.vaadin.testbench.TestBench;
 
 /**
@@ -32,22 +36,36 @@ public class AbstractNoW3c extends AbstractComponentIT {
 
     @Override
     public void setup() throws Exception {
-        if (getRunOnHub(getClass()) != null
-                        || Parameters.getHubHostname() != null) {
-
-            ChromeOptions options = new ChromeOptions();
-            options.addArguments(
-                    new String[] { "--headless", "--disable-gpu" });
-            options.setExperimentalOption("w3c", false);
-
-            options.merge(getDesiredCapabilities());
+        final WebDriver webDriver = createChromeDriverWithoutW3c(
+            getLocalExecution(), getDesiredCapabilities(), getHubURL());
+        if (webDriver != null) {
             setDesiredCapabilities(getDesiredCapabilities());
-
-            WebDriver driver = TestBench.createDriver(
-                    new RemoteWebDriver(new URL(getHubURL()), options));
-            setDriver(driver);
+            setDriver(webDriver);
         } else {
             super.setup();
         }
+    }
+
+    public static WebDriver createChromeDriverWithoutW3c(
+        Optional<LocalExecution> localExecution, DesiredCapabilities capabilities, String hubURL) throws Exception {
+
+        final ChromeOptions options = createChromeOptions();
+        options.merge(capabilities);
+
+        if(!localExecution.isPresent()) {
+            return TestBench.createDriver(
+                new RemoteWebDriver(new URL(hubURL), options));
+        }else if(localExecution.get().value() == Browser.CHROME) {
+            return TestBench.createDriver(new ChromeDriver(options));
+        }
+        return null;
+    }
+
+    private static ChromeOptions createChromeOptions() {
+        final ChromeOptions options = new ChromeOptions();
+        options.addArguments(
+            new String[] { "--headless", "--disable-gpu" });
+        options.setExperimentalOption("w3c", false);
+        return options;
     }
 }

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewIT.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewIT.java
@@ -15,16 +15,15 @@
  */
 package com.vaadin.flow.component.grid.it;
 
-import java.net.URL;
-import java.util.Collections;
-import java.util.List;
-import java.util.Locale;
-import java.util.logging.Level;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
+import com.vaadin.flow.component.AbstractNoW3c;
+import com.vaadin.flow.component.grid.ColumnTextAlign;
+import com.vaadin.flow.component.grid.testbench.GridColumnElement;
+import com.vaadin.flow.component.grid.testbench.GridElement;
+import com.vaadin.flow.component.grid.testbench.GridTHTDElement;
+import com.vaadin.flow.component.grid.testbench.GridTRElement;
+import com.vaadin.flow.data.provider.QuerySortOrder;
+import com.vaadin.flow.demo.TabbedComponentDemoTest;
+import com.vaadin.testbench.TestBenchElement;
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Ignore;
@@ -33,20 +32,16 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.interactions.Actions;
-import org.openqa.selenium.remote.RemoteWebDriver;
 
-import com.vaadin.flow.component.grid.ColumnTextAlign;
-import com.vaadin.flow.component.grid.testbench.GridColumnElement;
-import com.vaadin.flow.component.grid.testbench.GridElement;
-import com.vaadin.flow.component.grid.testbench.GridTHTDElement;
-import com.vaadin.flow.component.grid.testbench.GridTRElement;
-import com.vaadin.flow.data.provider.QuerySortOrder;
-import com.vaadin.flow.demo.TabbedComponentDemoTest;
-import com.vaadin.testbench.Parameters;
-import com.vaadin.testbench.TestBench;
-import com.vaadin.testbench.TestBenchElement;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.logging.Level;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 /**
  * Integration tests for the {@link GridView}.
@@ -57,20 +52,12 @@ public class GridViewIT extends TabbedComponentDemoTest {
 
     @Override
     public void setup() throws Exception {
-        if (getRunOnHub(getClass()) != null
-                || Parameters.getHubHostname() != null) {
-
-            ChromeOptions options = new ChromeOptions();
-            options.addArguments(
-                    new String[] { "--headless", "--disable-gpu" });
-            options.setExperimentalOption("w3c", false);
-
-            options.merge(getDesiredCapabilities());
+        final WebDriver webDriver = AbstractNoW3c
+            .createChromeDriverWithoutW3c(getLocalExecution(),
+                getDesiredCapabilities(), getHubURL());
+        if (webDriver != null) {
             setDesiredCapabilities(getDesiredCapabilities());
-
-            WebDriver driver = TestBench.createDriver(
-                    new RemoteWebDriver(new URL(getHubURL()), options));
-            setDriver(driver);
+            setDriver(webDriver);
         } else {
             super.setup();
         }


### PR DESCRIPTION
https://github.com/vaadin/vaadin-grid-flow/pull/674 fixed an issue in
chrome driver by disabling the w3c mode. This has broken local running
of tests. This should allow the tests to run both locally and on
teamcity.