### PR TITLE
Remove usage of DndUtil which is in Flow internal

### DIFF
--- a/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridDnDTest.java
+++ b/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridDnDTest.java
@@ -11,14 +11,12 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dnd.DropEvent;
 import com.vaadin.flow.component.dnd.DropTarget;
 import com.vaadin.flow.component.dnd.EffectAllowed;
-import com.vaadin.flow.component.dnd.internal.DndUtil;
 import com.vaadin.flow.component.grid.dnd.GridDragEndEvent;
 import com.vaadin.flow.component.grid.dnd.GridDragStartEvent;
 import com.vaadin.flow.router.RouterLink;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 import elemental.json.Json;
 import elemental.json.JsonArray;
@@ -55,7 +53,7 @@ public class GridDnDTest {
         ComponentUtil.fireEvent(grid, startEvent);
 
         Assert.assertEquals("No active drag source set", grid, ui.getActiveDragSourceComponent());
-        Assert.assertEquals("No drag data set", dragData, ComponentUtil.getData(grid, DndUtil.DRAG_SOURCE_DATA_KEY));
+        Assert.assertEquals("No drag data set", dragData, ComponentUtil.getData(grid, Grid.DRAG_SOURCE_DATA_KEY));
 
         AtomicReference<DropEvent<RouterLink>> eventCapture = new AtomicReference<>();
         RouterLink routerLink = new RouterLink() {
@@ -77,7 +75,7 @@ public class GridDnDTest {
         ComponentUtil.fireEvent(grid, new GridDragEndEvent<>(grid, true));
 
         Assert.assertNull("Active drag source not cleared", ui.getActiveDragSourceComponent());
-        Assert.assertNull("Drag data not cleared", ComponentUtil.getData(grid, DndUtil.DRAG_SOURCE_DATA_KEY));
+        Assert.assertNull("Drag data not cleared", ComponentUtil.getData(grid, Grid.DRAG_SOURCE_DATA_KEY));
     }
 
 }

--- a/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridDndMobilePolyfillTest.java
+++ b/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/GridDndMobilePolyfillTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.component.grid;
+
+import java.util.Properties;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.grid.dnd.GridDropMode;
+import com.vaadin.flow.server.DefaultDeploymentConfiguration;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.VaadinServlet;
+import com.vaadin.flow.server.VaadinSession;
+import com.vaadin.flow.server.WebBrowser;
+
+public class GridDndMobilePolyfillTest {
+
+    private Grid<String> grid;
+    private UI ui;
+
+    @Before
+    public void setup() {
+        DefaultDeploymentConfiguration configuration = new DefaultDeploymentConfiguration(
+                VaadinServlet.class, new Properties()) {
+            @Override
+            public boolean isCompatibilityMode() {
+                return false;
+            }
+        };
+
+        VaadinService service = Mockito.mock(VaadinService.class);
+        Mockito.when(service.resolveResource(Mockito.anyString(),
+                Mockito.any(WebBrowser.class))).thenReturn("");
+
+        VaadinSession session = Mockito.mock(VaadinSession.class);
+        Mockito.when(session.getConfiguration()).thenReturn(configuration);
+        Mockito.when(session.getService()).thenReturn(service);
+        Mockito.when(session.hasLock()).thenReturn(true);
+        ui = new UI() {
+            @Override
+            public VaadinSession getSession() {
+                return session;
+            }
+        };
+        ui.getInternals().setSession(session);
+
+        grid = new Grid<>();
+        ui.add(grid);
+    }
+
+    @Test
+    public void gridDnd_setDropMode_mobilePolyfillShouldBeAdded() {
+        grid.setDropMode(GridDropMode.ON_GRID);
+        Assert.assertEquals(
+                "Grid::setDropMode should add DnD mobile polyfill script to the UI.",
+                1, ui.getInternals().dumpPendingJavaScriptInvocations().size());
+    }
+
+    @Test
+    public void gridDnd_setRowsDraggable_mobilePolyfillShouldBeAdded() {
+        grid.setRowsDraggable(true);
+        Assert.assertEquals(
+                "Grid::setRowsDraggable should add DnD mobile polyfill script to the UI.",
+                1, ui.getInternals().dumpPendingJavaScriptInvocations().size());
+    }
+}


### PR DESCRIPTION
Since `com.vaadin.flow.component.dnd.internal` is not among exported packages of `flow-dnd` in an OSGi environment, we shouldn't use `DndUtil` class which is in that package. So instead of calling `DndUtil.addMobileDndPolyfillIfNeeded` directly, `DropTarget.create` and `DragSource.create` are called.

See https://github.com/vaadin/flow/pull/7291 for more details.