### PR TITLE
Remove FooterRow from Grid (fixes #922)

### DIFF
--- a/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/ColumnLayer.java
+++ b/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/ColumnLayer.java
@@ -189,6 +189,13 @@ class ColumnLayer implements Serializable {
     }
 
     /**
+     * Removes the FooterRow of this layer.
+     */
+    protected void removeFooterRow() {
+        footerRow = null;
+    }
+
+    /**
      * Gets the Grid that owns this layer of columns.
      * 
      * @return the grid that owns this layer

--- a/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -2108,6 +2108,28 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
         return insertColumnLayer(getLastFooterLayerIndex() + 1).asFooterRow();
     }
 
+
+    /**
+     * Removes all footer rows of the grid.
+     * <p>
+     * It can be used to recalculate the footer rows. Therefore you have to remove all footers and the recalculated
+     * footer rows.
+     */
+    public void removeAllFooterRows() {
+        columnLayers.stream()
+                .filter(ColumnLayer::isFooterRow)
+                .map(columnLayer -> {
+                    if (columnLayer.isHeaderRow()) {
+                        columnLayer.removeFooterRow();
+                        return null;
+                    } else {
+                        return columnLayer;
+                    }
+                })
+                .filter(Objects::nonNull)
+                .forEach(this::removeColumnLayer);
+    }
+
     protected List<ColumnLayer> getColumnLayers() {
         return Collections.unmodifiableList(columnLayers);
     }


### PR DESCRIPTION
Added method to remove footer rows in order to display dynamic contents in footer rows.

fixes #922