### PR TITLE
Reset TreeGrid connector on refreshAll (#950)

### DIFF
--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridFilterExpandView.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/treegrid/it/TreeGridFilterExpandView.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.treegrid.it;
+
+import com.vaadin.flow.component.html.Input;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.component.treegrid.TreeGrid;
+import com.vaadin.flow.data.provider.hierarchy.TreeData;
+import com.vaadin.flow.data.provider.hierarchy.TreeDataProvider;
+import com.vaadin.flow.data.value.ValueChangeMode;
+import com.vaadin.flow.router.Route;
+
+@SuppressWarnings("serial")
+@Route("treegrid-filter-expand")
+public class TreeGridFilterExpandView extends VerticalLayout {
+
+    public TreeGridFilterExpandView() {
+        setSizeFull();
+
+        TreeGrid<String> grid = new TreeGrid<>();
+        grid.addHierarchyColumn(s -> s);
+        TreeDataProvider<String> dataProvider = new TreeDataProvider<>(
+                generateData());
+        grid.setDataProvider(dataProvider);
+
+        Input filterField = new Input();
+        filterField.setValueChangeMode(ValueChangeMode.EAGER);
+
+        filterField.addValueChangeListener(event -> {
+            if (event.getValue() == null) {
+                dataProvider.setFilter(null);
+            } else {
+                dataProvider.setFilter(item -> item.toLowerCase()
+                        .contains(event.getValue().toLowerCase()));
+            }
+            grid.expandRecursively(dataProvider.getTreeData().getRootItems(),
+                    99);
+        });
+        add(filterField, grid);
+    }
+
+    /**
+     * The conditions for bug
+     * https://github.com/vaadin/vaadin-grid-flow/issues/891 are quite specific,
+     * and hard to figure out exactly, so this data should not be changed in
+     * order to keep the test valid.
+     */
+    private TreeData<String> generateData() {
+        TreeData<String> data = new TreeData<>();
+
+        data.addRootItems("planning", "transportation", "personnel logistics",
+                "vessel log", "configuration", "system", "user data");
+
+        data.addItems("planning", //
+                "operational plan", "transportation plan", "group schedule",
+                "bulk schedule", "personnel schedule", "generate schedule log",
+                "line overview", "resource plan", "shift plan");
+
+        data.addItems("transportation", //
+                "transportation summary", "visual transportation summary",
+                "visual status", "visual analysis", "map", "ata/atd",
+                "dfr control", "dummy transportation", "traffic log");
+
+        data.addItems("personnel logistics", //
+                "reservation", "check-in", "request & approval",
+                "group schedule: request & approval", "pob plan",
+                "approve purpose of visit", "approve replacement", "cargo",
+                "standby", "waiting list", "upload reservation",
+                "information to traveller", "reservations with deviations",
+                "move to new company / department / job",
+                "charter reservations", "reservation overview",
+                "terminal process");
+        data.addItems("terminal process", //
+                "id control", "luggage drop", "security control",
+                "survival suit delivery", "safety briefing",
+                "terminal overview");
+
+        data.addItems("vessel log", //
+                "vessel activities", "vessel current totals");
+
+        return data;
+    }
+
+}

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridFilterExpandIT.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridFilterExpandIT.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.treegrid.it;
+
+import java.util.stream.IntStream;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+
+@TestPath("treegrid-filter-expand")
+public class TreeGridFilterExpandIT extends AbstractTreeGridIT {
+
+    @Before
+    public void before() {
+        open();
+        setupTreeGrid();
+    }
+
+    @Test // https://github.com/vaadin/vaadin-grid-flow/issues/891
+    public void filterAndExpandAllMultipleTimes_correctItemsShown()
+            throws InterruptedException {
+        TestBenchElement filterField = $("input").first();
+
+        // Typing two letters with ValueChangeMode.EAGER on the field to trigger
+        // two filtering updates.
+        filterField.sendKeys("ap");
+
+        // Because of the way that the connector forcefully updates grid's
+        // cache, and the incorrect updates are coming asynchronously, there
+        // seems to be no way of checking when all the requests have been
+        // responded, and no more forceful updates are coming.
+        Thread.sleep(2000);
+
+        String[] expectedTextContents = new String[] { "transportation", "map",
+                "personnel logistics", "request & approval",
+                "group schedule: request & approval",
+                "approve purpose of visit", "approve replacement" };
+
+        Assert.assertArrayEquals(expectedTextContents, getActualTextContents());
+    }
+
+    private String[] getActualTextContents() {
+        return IntStream.range(0, getTreeGrid().getRowCount())
+                .mapToObj(i -> getTreeGrid().getCell(i, 0).getText())
+                .toArray(String[]::new);
+    }
+
+}

--- a/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
+++ b/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/treegrid/TreeGrid.java
@@ -36,6 +36,7 @@ import com.vaadin.flow.component.grid.GridArrayUpdater;
 import com.vaadin.flow.component.grid.GridArrayUpdater.UpdateQueueData;
 import com.vaadin.flow.data.binder.PropertyDefinition;
 import com.vaadin.flow.data.provider.CompositeDataGenerator;
+import com.vaadin.flow.data.provider.DataChangeEvent;
 import com.vaadin.flow.data.provider.DataCommunicator;
 import com.vaadin.flow.data.provider.DataProvider;
 import com.vaadin.flow.data.provider.hierarchy.HasHierarchicalDataProvider;
@@ -140,6 +141,8 @@ public class TreeGrid<T> extends Grid<T>
 
     private final ValueProvider<T, String> defaultUniqueKeyProvider = item -> String
             .valueOf(item.hashCode());
+
+    private Registration dataProviderRegistration;
 
     /**
      * Creates a new {@code TreeGrid} without support for creating columns based
@@ -281,8 +284,17 @@ public class TreeGrid<T> extends Grid<T>
         if (!(dataProvider instanceof HierarchicalDataProvider)) {
             throw new IllegalArgumentException(
                     "TreeGrid only accepts hierarchical data providers. "
-                        + "An example of interface to be used: HierarchicalDataProvider");
+                            + "An example of interface to be used: HierarchicalDataProvider");
         }
+        if (dataProviderRegistration != null) {
+            dataProviderRegistration.remove();
+        }
+        dataProviderRegistration = dataProvider.addDataProviderListener(e -> {
+            if (!(e instanceof DataChangeEvent.DataRefreshEvent)) {
+                // refreshAll was called
+                getElement().callJsFunction("$connector.reset");
+            }
+        });
         super.setDataProvider(dataProvider);
     }
 


### PR DESCRIPTION
Fixes #891.

By clearing the connector from all the pending stuff from previous
refresh, the data is not messed up by updates from outdated requests.

This seems to also help with the slowness of the updates at least to
some extent.