### PR TITLE
Make project compile with Java 11

### DIFF
--- a/vaadin-grid-flow-integration-tests/pom.xml
+++ b/vaadin-grid-flow-integration-tests/pom.xml
@@ -180,5 +180,37 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <!-- Need to exclude problematic memory testing classes with Java11,
+            because those currently use internal Nashorn classes for
+            object size measurement and are not available in Java 11. -->
+            <id>java11</id>
+            <activation>
+                <jdk>11</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <excludes>
+                                <exclude>
+                                    com/vaadin/flow/data/performance/AbstractBeansMemoryTest.java
+                                </exclude>
+                                <exclude>
+                                    com/vaadin/flow/data/performance/TreeGridMemory.java
+                                </exclude>
+                            </excludes>
+                            <testExcludes>
+                                <testExclude>
+                                    com/vaadin/flow/component/treegrid/it/TreeGridHugeTreeIT.java
+                                </testExclude>
+                            </testExcludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
Nashorn has been removed in JDK 11 so its internals cannot be used
for object memory calculation. This just excludes the problematic test
classes from compilation automatically when Java 11 is used.