### PR TITLE
Optimize sorting request

### DIFF
--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridDataProviderSize.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridDataProviderSize.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.it;
+
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.grid.GridSortOrder;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.data.provider.AbstractBackEndDataProvider;
+import com.vaadin.flow.data.provider.Query;
+import com.vaadin.flow.data.provider.SortDirection;
+import com.vaadin.flow.router.Route;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+/**
+ * @author Vaadin Ltd.
+ */
+@Route("grid-data-provider-size")
+public class GridDataProviderSize extends Div {
+
+    public GridDataProviderSize() {
+        final Grid<String> grid = new Grid<>();
+        final Grid.Column<String> col = grid.addColumn(it -> it).setHeader("First column");
+
+        Div div = new Div();
+        div.setText("0");
+        div.setId("info");
+
+        grid.setDataProvider(new AbstractBackEndDataProvider<String, Object>() {
+            @Override
+            protected Stream<String> fetchFromBackEnd(Query<String, Object> query) {
+                return Stream.of();
+            }
+
+            @Override
+            protected int sizeInBackEnd(Query<String, Object> query) {
+                Integer count = Integer.parseInt(div.getText()) + 1;
+                div.setText(count.toString());
+                return 0;
+            }
+        });
+
+        grid.sort(Arrays.asList(new GridSortOrder<>(col, SortDirection.ASCENDING)));
+        add(grid, div);
+    }
+
+}

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridDataProviderSizeIT.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridDataProviderSizeIT.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.it;
+
+import com.vaadin.flow.testutil.AbstractComponentIT;
+import com.vaadin.flow.testutil.TestPath;
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+@TestPath("grid-data-provider-size")
+public class GridDataProviderSizeIT extends AbstractComponentIT {
+
+    @Test
+    public void sizeInBackEndCalledOnce() {
+        open();
+
+        WebElement info = findElement(By.id("info"));
+        Assert.assertEquals("sizeInBackEnd should be called once", "1", info.getText());
+    }
+}

--- a/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -412,24 +412,21 @@ import { ItemCache } from '@vaadin/vaadin-grid/src/vaadin-grid-data-provider-mix
         sorterDirectionsSetFromServer = true;
         setTimeout(tryCatchWrapper(() => {
           try {
-            const existingSorters = Array.from(grid.querySelectorAll('vaadin-grid-sorter'));
-            const updatedSorters = directions
-                .map(direction => direction.column)
-                .map(columnId => grid.querySelector("vaadin-grid-sorter[path='" + columnId + "']"));
+            const sorters = Array.from(grid.querySelectorAll('vaadin-grid-sorter'));
 
-            existingSorters
-                .filter(sorter => updatedSorters.indexOf(sorter) === -1)
-                .forEach(sorter => sorter.direction = null);
-
-            for (let i = directions.length - 1; i >= 0; i--) {
-              const columnId = directions[i].column;
-              const direction = directions[i].direction;
-
-              const sorter = grid.querySelector("vaadin-grid-sorter[path='" + columnId + "']");
-              if (sorter && sorter.direction !== direction) {
-                sorter.direction = direction;
+            sorters.forEach(sorter => {
+              if (!directions.some(d => d.column === sorter.getAttribute('path'))) {
+                sorter.direction = null;
               }
-            }
+            });
+
+            directions.reverse().forEach(({column, direction}) => {
+              sorters.forEach(sorter => {
+                if (sorter.getAttribute('path') === column && sorter.direction !== direction) {
+                  sorter.direction = direction
+                }
+              });
+            });
           } finally {
             sorterDirectionsSetFromServer = false;
           }

--- a/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -421,12 +421,15 @@ import { ItemCache } from '@vaadin/vaadin-grid/src/vaadin-grid-data-provider-mix
                 .filter(sorter => updatedSorters.indexOf(sorter) === -1)
                 .forEach(sorter => sorter.direction = null);
 
-            directions.forEach(({column, direction}) => {
-              const sorter = grid.querySelector("vaadin-grid-sorter[path='" + column + "']");
+            for (let i = directions.length - 1; i >= 0; i--) {
+              const columnId = directions[i].column;
+              const direction = directions[i].direction;
+
+              const sorter = grid.querySelector("vaadin-grid-sorter[path='" + columnId + "']");
               if (sorter && sorter.direction !== direction) {
                 sorter.direction = direction;
               }
-            });
+            }
           } finally {
             sorterDirectionsSetFromServer = false;
           }

--- a/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -415,7 +415,7 @@ import { ItemCache } from '@vaadin/vaadin-grid/src/vaadin-grid-data-provider-mix
             const sorters = Array.from(grid.querySelectorAll('vaadin-grid-sorter'));
 
             sorters.forEach(sorter => {
-              if (!directions.some(d => d.column === sorter.getAttribute('path'))) {
+              if (!directions.filter(d => d.column === sorter.getAttribute('path'))[0]) {
                 sorter.direction = null;
               }
             });

--- a/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -399,7 +399,7 @@ import { ItemCache } from '@vaadin/vaadin-grid/src/vaadin-grid-data-provider-mix
 
       const sorterChangeListener = tryCatchWrapper(function(_, oldValue) {
         if (oldValue !== undefined && !sorterDirectionsSetFromServer) {
-          grid.$server.sortersChanged(grid._sorters.map(function(sorter) {
+          grid.$server.sortersChanged(grid._sorters.map(function (sorter) {
             return {
               path: sorter.path,
               direction: sorter.direction
@@ -412,16 +412,21 @@ import { ItemCache } from '@vaadin/vaadin-grid/src/vaadin-grid-data-provider-mix
         sorterDirectionsSetFromServer = true;
         setTimeout(tryCatchWrapper(() => {
           try {
-            let allSorters = grid.querySelectorAll("vaadin-grid-sorter");
-            allSorters.forEach(sorter => sorter.direction = null);
+            const existingSorters = Array.from(grid.querySelectorAll('vaadin-grid-sorter'));
+            const updatedSorters = directions
+                .map(direction => direction.column)
+                .map(columnId => grid.querySelector("vaadin-grid-sorter[path='" + columnId + "']"));
 
-            for (let i = directions.length - 1; i >= 0; i--) {
-              const columnId = directions[i].column;
-              let sorter = grid.querySelector("vaadin-grid-sorter[path='" + columnId + "']");
-              if (sorter) {
-                sorter.direction = directions[i].direction;
+            existingSorters
+                .filter(sorter => updatedSorters.indexOf(sorter) === -1)
+                .forEach(sorter => sorter.direction = null);
+
+            directions.forEach(({column, direction}) => {
+              const sorter = grid.querySelector("vaadin-grid-sorter[path='" + column + "']");
+              if (sorter && sorter.direction !== direction) {
+                sorter.direction = direction;
               }
-            }
+            });
           } finally {
             sorterDirectionsSetFromServer = false;
           }


### PR DESCRIPTION
Fixes #995 

**Short description:**
In the Flows [DataCommunicator](https://github.com/vaadin/flow/blob/master/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java) major part of the methods calls will lead to asking for [data-provider size](https://github.com/vaadin/flow/blob/2b945d6b193ddb260c92aaf9e15f69d1ca02130c/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java#L453). 
The initial sorting in grid-flow was fixed to be done [asynchronously](https://github.com/vaadin/vaadin-grid-flow/commit/7d34f6afac1f873331c4601340d48d6171271078#diff-18fd66d51777465fec3d9be42bac947cR417). Cleaning the direction for sorters at that point of time is leading to connector calling `ClientCallable` `sortersChanged` extra time. That will `requestFlush` from `DataCommunicator` and asking for data-provider size later on.

Extra call is avoided by updating only those sorters that have updated their directions.