### PR TITLE
Adjust for ItemCountChangeEvent::isCountEstimated

### DIFF
--- a/vaadin-grid-flow-demo/src/main/java/com/vaadin/flow/component/grid/demo/GridDemo.java
+++ b/vaadin-grid-flow-demo/src/main/java/com/vaadin/flow/component/grid/demo/GridDemo.java
@@ -745,7 +745,7 @@ public class GridDemo extends DemoView {
     private void createGridWithCustomItemCountEstimate() {
         // begin-source-example
         // source-example-heading: Fast Scroll with Custom Item Count Estimate
-        // the backend will have 12345 rows
+        // The backend will have 12345 items
         final ItemGenerator fakeBackend = new ItemGenerator(12345);
         Grid<Item> grid = new Grid<>();
 
@@ -764,14 +764,14 @@ public class GridDemo extends DemoView {
         lazyDataView.setItemCountEstimate(1000);
         lazyDataView.setItemCountEstimateIncrease(1000);
 
-        // showing the row count for demo purposes
+        // Showing the item count for demo purposes
         Div countText = new Div();
         lazyDataView.addItemCountChangeListener(event -> {
             if (event.isItemCountEstimated()) {
                 countText
-                        .setText("Row Count Estimate: " + event.getItemCount());
+                        .setText("Item Count Estimate: " + event.getItemCount());
             } else {
-                countText.setText("Exact size: " + event.getItemCount());
+                countText.setText("Exact Item Count: " + event.getItemCount());
             }
         });
         

--- a/vaadin-grid-flow-demo/src/main/java/com/vaadin/flow/component/grid/demo/GridDemo.java
+++ b/vaadin-grid-flow-demo/src/main/java/com/vaadin/flow/component/grid/demo/GridDemo.java
@@ -20,6 +20,7 @@ import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.stream.Collectors;
 
+import com.vaadin.flow.component.Text;
 import com.vaadin.flow.component.grid.dataview.GridLazyDataView;
 import org.apache.commons.lang3.StringUtils;
 
@@ -744,12 +745,13 @@ public class GridDemo extends DemoView {
     private void createGridWithCustomItemCountEstimate() {
         // begin-source-example
         // source-example-heading: Fast Scroll with Custom Item Count Estimate
-        Grid<Person> grid = new Grid<>();
-        PersonService personService = new PersonService();
+        // the backend will have 12345 rows
+        final ItemGenerator fakeBackend = new ItemGenerator(12345);
+        Grid<Item> grid = new Grid<>();
 
-        GridLazyDataView<Person> lazyDataView = grid
-                .setItems(query -> personService
-                        .fetch(query.getOffset(), query.getLimit()).stream());
+        GridLazyDataView<Item> lazyDataView = grid
+                .setItems(query -> fakeBackend
+                        .generateItems(query.getOffset(), query.getLimit()));
         /*
          * By default the grid will initially adjust the scrollbar to 200 items
          * and as the user scrolls down it automatically increases the size by
@@ -762,15 +764,35 @@ public class GridDemo extends DemoView {
         lazyDataView.setItemCountEstimate(1000);
         lazyDataView.setItemCountEstimateIncrease(1000);
 
-        grid.addColumn(Person::getFirstName).setHeader("First Name");
-        grid.addColumn(Person::getLastName).setHeader("Last Name");
-        grid.addColumn(Person::getAge).setHeader("Age");
+        // showing the row count for demo purposes
+        Div countText = new Div();
+        lazyDataView.addItemCountChangeListener(event -> {
+            if (event.isItemCountEstimated()) {
+                countText
+                        .setText("Row Count Estimate: " + event.getItemCount());
+            } else {
+                countText.setText("Exact size: " + event.getItemCount());
+            }
+        });
+        
+        VerticalLayout layout = new VerticalLayout(grid, countText);
+
+        grid.addColumn(Item::getName).setHeader("Name").setWidth("20px");
+        grid.addColumn(new NumberRenderer<>(Item::getPrice, "$ %(,.2f",
+                Locale.US, "$ 0.00")).setHeader("Price");
+        grid.addColumn(new LocalDateTimeRenderer<>(Item::getPurchaseDate,
+                DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT,
+                        FormatStyle.MEDIUM)))
+                .setHeader("Purchase Date and Time").setFlexGrow(2);
+        grid.addColumn(new LocalDateRenderer<>(Item::getEstimatedDeliveryDate,
+                DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM)))
+                .setHeader("Estimated Delivery Date");
         // end-source-example
 
         grid.setId("custom-item-count-estimate");
 
         addCard("Lazy Loading", "Fast Scroll with Custom Item Count Estimate",
-                grid);
+                layout);
     }
 
     private void createGridWithExactItemCount() {

--- a/vaadin-grid-flow-demo/src/main/java/com/vaadin/flow/component/grid/demo/ItemGenerator.java
+++ b/vaadin-grid-flow-demo/src/main/java/com/vaadin/flow/component/grid/demo/ItemGenerator.java
@@ -20,6 +20,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import com.vaadin.flow.component.grid.demo.GridDemo.Item;
 
@@ -31,11 +32,31 @@ import com.vaadin.flow.component.grid.demo.GridDemo.Item;
  */
 class ItemGenerator extends BeanGenerator {
 
+    private final int numberOfRows;
+
+    public ItemGenerator() {
+        numberOfRows = -1;
+    }
+
+    public ItemGenerator(int numberOfRows) {
+        this.numberOfRows = numberOfRows;
+    }
+
     public List<Item> generateItems(int amount) {
         LocalDate baseDate = LocalDate.of(2018, 1, 10);
         return IntStream.range(0, amount)
                 .mapToObj(index -> createItem(index + 1, baseDate))
                 .collect(Collectors.toList());
+    }
+
+    public Stream<Item> generateItems(int offset, int limit) {
+        LocalDate baseDate = LocalDate.of(2020, 1, 10);
+        int end = offset + limit;
+        if (numberOfRows > 0 && numberOfRows < end) {
+            end = numberOfRows;
+        }
+        return IntStream.range(offset, end)
+                .mapToObj(index -> createItem(index + 1, baseDate));
     }
 
     private Item createItem(int index, LocalDate baseDate) {

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/dataview/AbstractItemCountGridPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/dataview/AbstractItemCountGridPage.java
@@ -67,7 +67,7 @@ public abstract class AbstractItemCountGridPage extends VerticalLayout
     public static final String DEFINED_SIZE_BUTTON_ID = "defined-size";
     public static final String DATA_PROVIDER_BUTTON_ID = "data-provider";
     public static final String ITEM_COUNT_ESTIMATE_INPUT = "item-count-estimate-input";
-    public static final String ITEM_COUNT_ESTIMATE_STEP_INPUT = "item-count-estimate-step-input";
+    public static final String ITEM_COUNT_ESTIMATE_INCREASE_INPUT = "item-count-estimate-increase-input";
     public static final String DATA_PROVIDER_SIZE_INPUT_ID = "data-provider-size-input";
     public static final String UNDEFINED_SIZE_BACKEND_SIZE_INPUT_ID = "fetchcallback";
     public static final int DEFAULT_DATA_PROVIDER_SIZE = 1000;
@@ -76,7 +76,7 @@ public abstract class AbstractItemCountGridPage extends VerticalLayout
     private VerticalLayout menuBar;
     private Div logPanel;
     protected IntegerField itemCountEstimateInput;
-    protected IntegerField itemCountEstimateStepInput;
+    protected IntegerField itemCountEstimateIncreaseInput;
     protected IntegerField fetchCallbackSizeInput;
     protected IntegerField dataProviderSizeInput;
     protected Grid<String> grid;
@@ -193,12 +193,12 @@ public abstract class AbstractItemCountGridPage extends VerticalLayout
         itemCountEstimateInput.setId(ITEM_COUNT_ESTIMATE_INPUT);
         itemCountEstimateInput.setWidthFull();
 
-        itemCountEstimateStepInput = new IntegerField(
-                "setItemCountEstimateStep",
+        itemCountEstimateIncreaseInput = new IntegerField(
+                "setItemCountEstimateIncrease",
                 event -> grid.getLazyDataView().setItemCountEstimateIncrease(event.getValue()));
-        itemCountEstimateStepInput.setId(ITEM_COUNT_ESTIMATE_STEP_INPUT);
-        itemCountEstimateStepInput.setWidthFull();
-        menuBar.add(itemCountEstimateInput, itemCountEstimateStepInput);
+        itemCountEstimateIncreaseInput.setId(ITEM_COUNT_ESTIMATE_INCREASE_INPUT);
+        itemCountEstimateIncreaseInput.setWidthFull();
+        menuBar.add(itemCountEstimateInput, itemCountEstimateIncreaseInput);
     }
 
     private void initDataCommunicatorOptions() {

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/dataview/AbstractItemCountGridPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/dataview/AbstractItemCountGridPage.java
@@ -117,7 +117,7 @@ public abstract class AbstractItemCountGridPage extends VerticalLayout
         menuBar.add(new RouterLink("InitialSizeEstimate",
                 ItemCountEstimateGridPage.class));
         menuBar.add(new RouterLink("SizeEstimateCallback",
-                ItemCountEstimateStepGridPage.class));
+                ItemCountEstimateIncreaseGridPage.class));
         menuBar.add(new RouterLink("DefinedSize",
                 ItemCountCallbackGridPage.class));
     }

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/dataview/ItemCountEstimateIncreaseGridPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/dataview/ItemCountEstimateIncreaseGridPage.java
@@ -19,13 +19,13 @@ package com.vaadin.flow.component.grid.it.dataview;
 import com.vaadin.flow.router.BeforeEnterEvent;
 import com.vaadin.flow.router.Route;
 
-@Route("item-count-estimate-step/:step?([0-9]{1,9})")
-public class ItemCountEstimateStepGridPage
+@Route("item-count-estimate-increase/:increase?([0-9]{1,9})")
+public class ItemCountEstimateIncreaseGridPage
         extends AbstractItemCountGridPage {
 
     @Override
     public void beforeEnter(BeforeEnterEvent event) {
-        event.getRouteParameters().get("step").ifPresent(string -> {
+        event.getRouteParameters().get("increase").ifPresent(string -> {
             int size = Integer.parseInt(string);
             itemCountEstimateStepInput.setValue(size);
         });

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/dataview/ItemCountEstimateIncreaseGridPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/dataview/ItemCountEstimateIncreaseGridPage.java
@@ -27,7 +27,7 @@ public class ItemCountEstimateIncreaseGridPage
     public void beforeEnter(BeforeEnterEvent event) {
         event.getRouteParameters().get("increase").ifPresent(string -> {
             int size = Integer.parseInt(string);
-            itemCountEstimateStepInput.setValue(size);
+            itemCountEstimateIncreaseInput.setValue(size);
         });
     }
 }

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/dataview/AbstractItemCountGridIT.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/dataview/AbstractItemCountGridIT.java
@@ -80,10 +80,10 @@ public abstract class AbstractItemCountGridIT extends AbstractComponentIT {
                 .setValue(size + "");
     }
 
-    protected void setEstimateStep(int estimate) {
+    protected void setEstimateIncrease(int estimateIncrease) {
         $(IntegerFieldElement.class).id(
                 AbstractItemCountGridPage.ITEM_COUNT_ESTIMATE_STEP_INPUT)
-                .setValue(estimate + "");
+                .setValue(estimateIncrease + "");
     }
 
     protected void setEstimate(int estimate) {

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/dataview/AbstractItemCountGridIT.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/dataview/AbstractItemCountGridIT.java
@@ -82,7 +82,7 @@ public abstract class AbstractItemCountGridIT extends AbstractComponentIT {
 
     protected void setEstimateIncrease(int estimateIncrease) {
         $(IntegerFieldElement.class).id(
-                AbstractItemCountGridPage.ITEM_COUNT_ESTIMATE_STEP_INPUT)
+                AbstractItemCountGridPage.ITEM_COUNT_ESTIMATE_INCREASE_INPUT)
                 .setValue(estimateIncrease + "");
     }
 

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/dataview/ItemCountEstimateGridIT.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/dataview/ItemCountEstimateGridIT.java
@@ -109,4 +109,15 @@ public class ItemCountEstimateGridIT extends AbstractItemCountGridIT {
         verifyRows(1300);
     }
 
+    @Test
+    public void customIncrease_scrollsFarFromExactCount_countIsResolved() {
+        open(3000);
+        verifyRows(3000);
+        setUnknownCountBackendSize(469);
+
+        grid.scrollToRow(1000);
+
+        verifyRows(469);
+    }
+
 }

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/dataview/ItemCountEstimateIncreaseGridIT.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/dataview/ItemCountEstimateIncreaseGridIT.java
@@ -63,8 +63,9 @@ public class ItemCountEstimateIncreaseGridIT extends AbstractItemCountGridIT {
     @Test
     public void customIncrease_scrollsFarFromExactCount_countIsResolved() {
         open(3000);
-        verifyRows(3000);
         setUnknownCountBackendSize(469);
+        grid.scrollToRow(200);
+        verifyRows(3200);
 
         grid.scrollToRow(1000);
 

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/dataview/ItemCountEstimateIncreaseGridIT.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/dataview/ItemCountEstimateIncreaseGridIT.java
@@ -20,31 +20,31 @@ import com.vaadin.flow.testutil.TestPath;
 import org.junit.Assert;
 import org.junit.Test;
 
-@TestPath("item-count-estimate-step")
-public class ItemCountEstimateStepGridIT extends AbstractItemCountGridIT {
+@TestPath("item-count-estimate-increase")
+public class ItemCountEstimateIncreaseGridIT extends AbstractItemCountGridIT {
 
     @Test
-    public void customStep_scrollingPastEstimate_estimateIncreased() {
-        int customStep = 333;
-        open(customStep);
+    public void customIncrease_scrollingPastEstimate_estimateIncreased() {
+        int customIncrease = 333;
+        open(customIncrease);
 
         verifyRows(getDefaultInitialItemCount());
 
         grid.scrollToRow(190);
 
-        int newCount = getDefaultInitialItemCount() + customStep;
+        int newCount = getDefaultInitialItemCount() + customIncrease;
         verifyRows(newCount);
 
-        customStep = 500;
-        setEstimateStep(customStep);
+        customIncrease = 500;
+        setEstimateIncrease(customIncrease);
 
         grid.scrollToRow(newCount - 10);
 
-        verifyRows(newCount + customStep);
+        verifyRows(newCount + customIncrease);
     }
 
     @Test
-    public void customStep_reachesEndBeforeEstimate_sizeChanges() {
+    public void customIncrease_reachesEndBeforeEstimate_sizeChanges() {
         open(300);
 
         verifyRows(200);
@@ -61,7 +61,18 @@ public class ItemCountEstimateStepGridIT extends AbstractItemCountGridIT {
     }
 
     @Test
-    public void customStepScrolledToEnd_newStepSet_newEstimateSizeNotApplied() {
+    public void customIncrease_scrollsFarFromExactCount_countIsResolved() {
+        open(3000);
+        verifyRows(3000);
+        setUnknownCountBackendSize(469);
+
+        grid.scrollToRow(1000);
+
+        verifyRows(469);
+    }
+
+    @Test
+    public void customIncreaseScrolledToEnd_newIncreaseSet_newEstimateSizeNotApplied() {
         open(300);
         int unknownCountBackendSize = 444;
         setUnknownCountBackendSize(unknownCountBackendSize);
@@ -76,7 +87,7 @@ public class ItemCountEstimateStepGridIT extends AbstractItemCountGridIT {
 
         // since the end was reached, only a reset() to data provider will reset
         // estimated size
-        setEstimateStep(600);
+        setEstimateIncrease(600);
         verifyRows(unknownCountBackendSize);
         Assert.assertEquals("Last visible row wrong",
                 unknownCountBackendSize - 1, grid.getLastVisibleRowIndex());

--- a/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/dataview/GridDataViewTest.java
+++ b/vaadin-grid-flow/src/test/java/com/vaadin/flow/component/grid/dataview/GridDataViewTest.java
@@ -77,7 +77,7 @@ public class GridDataViewTest {
                 event -> fired.compareAndSet(0, event.getItemCount()));
 
         ComponentUtil.fireEvent(component,
-                new ItemCountChangeEvent<>(component, 10));
+                new ItemCountChangeEvent<>(component, 10, false));
 
         Assert.assertEquals(10, fired.get());
     }


### PR DESCRIPTION
Makes automatically extending grid demo more interesting.
Cleans up old terminology in tests about step instead of increase.

Part of vaadin/flow#8643