### PR TITLE
Connector cleanup

### DIFF
--- a/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -17,12 +17,7 @@ import { ItemCache } from '@vaadin/vaadin-grid/src/vaadin-grid-data-provider-mix
 
       ItemCache.prototype.ensureSubCacheForScaledIndex = tryCatchWrapper(function(scaledIndex) {
         if (!this.itemCaches[scaledIndex]) {
-
-          if(ensureSubCacheDelay) {
-            this.grid.$connector.beforeEnsureSubCacheForScaledIndex(this, scaledIndex);
-          } else {
-            this.doEnsureSubCacheForScaledIndex(scaledIndex);
-          }
+          this.grid.$connector.beforeEnsureSubCacheForScaledIndex(this, scaledIndex);
         }
       })
 
@@ -71,12 +66,6 @@ import { ItemCache } from '@vaadin/vaadin-grid/src/vaadin-grid-data-provider-mix
       const treePageCallbacks = {};
       const cache = {};
 
-      /* ensureSubCacheDelay - true optimizes scrolling performance by adding small
-      *  delay between each first page fetch of expanded item.
-      *  Disable by setting to false.
-      */
-      const ensureSubCacheDelay = true;
-
       /* parentRequestDelay - optimizes parent requests by batching several requests
       *  into one request. Delay in milliseconds. Disable by setting to 0.
       *  parentRequestBatchMaxSize - maximum size of the batch.
@@ -109,15 +98,11 @@ import { ItemCache } from '@vaadin/vaadin-grid/src/vaadin-grid-data-provider-mix
 
       grid.$connector = {};
 
-      grid.$connector.hasEnsureSubCacheQueue = tryCatchWrapper(function() {
-        return ensureSubCacheQueue.length > 0;
-      })
+      grid.$connector.hasEnsureSubCacheQueue = tryCatchWrapper(() => ensureSubCacheQueue.length > 0);
 
-      grid.$connector.hasParentRequestQueue = tryCatchWrapper(function() {
-        return parentRequestQueue.length > 0;
-      })
+      grid.$connector.hasParentRequestQueue = tryCatchWrapper(() => parentRequestQueue.length > 0);
 
-      grid.$connector.hasRootRequestQueue = tryCatchWrapper(function() {
+      grid.$connector.hasRootRequestQueue = tryCatchWrapper(() => {
         return Object.keys(rootPageCallbacks).length > 0 || (rootRequestDebouncer && rootRequestDebouncer.isActive());
       })
 
@@ -292,24 +277,20 @@ import { ItemCache } from '@vaadin/vaadin-grid/src/vaadin-grid-data-provider-mix
       })
 
       grid.$connector.beforeParentRequest = tryCatchWrapper(function(firstIndex, size, parentKey) {
-        if(parentRequestDelay > 0) {
-          // add request in queue
-          parentRequestQueue.push({
-            firstIndex: firstIndex,
-            size: size,
-            parentKey: parentKey
-          });
+        // add request in queue
+        parentRequestQueue.push({
+          firstIndex: firstIndex,
+          size: size,
+          parentKey: parentKey
+        });
 
-          parentRequestDebouncer = Debouncer.debounce(parentRequestDebouncer, timeOut.after(parentRequestDelay),
-            () => {
-              while (parentRequestQueue.length) {
-                grid.$connector.flushParentRequests();
-              }
+        parentRequestDebouncer = Debouncer.debounce(parentRequestDebouncer, timeOut.after(parentRequestDelay),
+          () => {
+            while (parentRequestQueue.length) {
+              grid.$connector.flushParentRequests();
             }
-          );
-        } else {
-          grid.$server.setParentRequestedRange(firstIndex, size, parentKey);
-        }
+          }
+        );
       })
 
       grid.$connector.fetchPage = tryCatchWrapper(function(fetch, page, parentKey) {
@@ -765,13 +746,9 @@ import { ItemCache } from '@vaadin/vaadin-grid/src/vaadin-grid-data-provider-mix
 
       const deleteObjectContents = obj => Object.keys(obj).forEach(key => delete obj[key]);
 
-      grid.$connector.updateSize = function(newSize) {
-        grid.size = newSize;
-      };
+      grid.$connector.updateSize = newSize => grid.size = newSize;
 
-      grid.$connector.updateUniqueItemIdPath = function(path) {
-        grid.itemIdPath = path;
-      }
+      grid.$connector.updateUniqueItemIdPath = path => grid.itemIdPath = path;
 
       grid.$connector.expandItems = tryCatchWrapper(function(items) {
         let newExpandedItems = Array.from(grid.expandedItems);


### PR DESCRIPTION
...for example, the internal flag `ensureSubCacheDelay` is fixed to `true`, and I don't see why this constant would be changed anytime soon in the future, so it's pointless to have logic in the connector that only applied if the flag was `false`.