### PR TITLE
fix: prevent NPE for client-side only grids

### DIFF
--- a/vaadin-grid-flow-integration-tests/frontend/src/grid-on-client-and-slot.js
+++ b/vaadin-grid-flow-integration-tests/frontend/src/grid-on-client-and-slot.js
@@ -1,0 +1,89 @@
+import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import '@vaadin/vaadin-grid/src/vaadin-grid.js';
+import '@vaadin/vaadin-grid/src/vaadin-grid-column.js';
+import '@vaadin/vaadin-grid/src/vaadin-grid-tree-toggle.js';
+
+class GridOnClientAndSlot extends PolymerElement {
+
+  static get template() {
+    return html`
+      <style>
+        :host {
+          display: flex;
+          flex-direction: column;
+          width: 100%;
+          height: 100%;
+          }
+      </style>
+
+      <vaadin-grid id="tree">
+        <vaadin-grid-column>
+          <template>
+            <vaadin-grid-tree-toggle leaf="[[item.leaf]]" expanded="{{expanded}}" level="[[level]]">
+              <div class="tree-cell">[[item.name]]</div>
+            </vaadin-grid-tree-toggle>
+          </template>
+        </vaadin-grid-column>
+      </vaadin-grid>
+      <button>This is a button</button>
+      <slot></slot>
+         `;
+  }
+
+  static get is() {
+    return 'grid-on-client-and-slot';
+  }
+
+  static get properties() {
+    return {
+      items: {
+        type: Array,
+        value: [
+          {
+            name: 'item 1',
+            leaf: false,
+            children: [
+              {
+                name: 'child 1-1',
+                leaf: true
+              },
+              {
+                name: 'child 1-2',
+                leaf: true
+              }
+            ]
+          },
+          {
+            name: 'item 2',
+            children: [
+              {
+                name: 'child 2-1',
+                leaf: true
+              },
+              {
+                name: 'child 2-2',
+                leaf: true
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+
+    this.$.tree.dataProvider = (params, callback) => {
+      if (params.parentItem != null) {
+        callback(params.parentItem.children, params.parentItem.children.length);
+      }
+      else {
+        callback(this.items, this.items.length);
+      }
+    };
+  }
+
+}
+
+customElements.define(GridOnClientAndSlot.is, GridOnClientAndSlot);

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridOnClientAndSlot.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridOnClientAndSlot.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.it;
+
+import com.vaadin.flow.component.HasComponents;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.dependency.JsModule;
+import com.vaadin.flow.component.polymertemplate.PolymerTemplate;
+import com.vaadin.flow.templatemodel.TemplateModel;
+
+@Tag("grid-on-client-and-slot")
+@JsModule("src/grid-on-client-and-slot.js")
+public class GridOnClientAndSlot extends PolymerTemplate<TemplateModel> implements HasComponents {
+}

--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridOnClientAndSlotPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridOnClientAndSlotPage.java
@@ -1,0 +1,19 @@
+package com.vaadin.flow.component.grid.it;
+
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.Route;
+
+@Route("grid-on-client-and-slot")
+public class GridOnClientAndSlotPage extends Div {
+    public GridOnClientAndSlotPage() {
+        GridOnClientAndSlot gridOnClientAndSlot = new GridOnClientAndSlot();
+        Grid<String> grid = new Grid<>();
+        grid.addColumn(String::toString).setHeader("Column");
+        grid.setItems("Item 1", "Item 2", "Item 3", "Item 4");
+        
+        gridOnClientAndSlot.add(grid);
+
+        add(gridOnClientAndSlot);
+    }
+}

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridOnClientAndServerIT.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridOnClientAndServerIT.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.grid.it;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.flow.component.grid.testbench.GridTHTDElement;
+import com.vaadin.flow.component.grid.testbench.TreeGridElement;
+import com.vaadin.flow.testutil.AbstractComponentIT;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+
+@TestPath("grid-on-client-and-slot")
+public class GridOnClientAndServerIT extends AbstractComponentIT {
+  
+  @Test
+  public void treeGridOnClientShouldWorkIfAnotherGridIsAddedFromServer() {
+    open();
+
+    TestBenchElement parent  = $("grid-on-client-and-slot").first();
+
+    TreeGridElement treeGrid = parent.$(TreeGridElement.class).id("tree");
+    treeGrid.getExpandToggleElement(0, 0).click();;
+    GridTHTDElement cell = treeGrid.getCell(1, 0);
+
+    Assert.assertEquals("child 1-1", cell.getText().trim());
+  }
+}

--- a/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -15,7 +15,15 @@ import { ItemCache } from '@vaadin/vaadin-grid/src/vaadin-grid-data-provider-mix
         return;
       }
 
+      // Storing original implementation of the method to be used for client
+      // side only grids
+      ItemCache.prototype.ensureSubCacheForScaledIndexOriginal = ItemCache.prototype.ensureSubCacheForScaledIndex;
       ItemCache.prototype.ensureSubCacheForScaledIndex = tryCatchWrapper(function(scaledIndex) {
+        if (!this.$connector) {
+          this.ensureSubCacheForScaledIndexOriginal(scaledIndex);
+          return;
+        }
+
         if (!this.itemCaches[scaledIndex]) {
 
           if(ensureSubCacheDelay) {

--- a/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
+++ b/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js
@@ -19,7 +19,7 @@ import { ItemCache } from '@vaadin/vaadin-grid/src/vaadin-grid-data-provider-mix
       // side only grids
       ItemCache.prototype.ensureSubCacheForScaledIndexOriginal = ItemCache.prototype.ensureSubCacheForScaledIndex;
       ItemCache.prototype.ensureSubCacheForScaledIndex = tryCatchWrapper(function(scaledIndex) {
-        if (!this.$connector) {
+        if (!this.grid.$connector) {
           this.ensureSubCacheForScaledIndexOriginal(scaledIndex);
           return;
         }


### PR DESCRIPTION
fix #1077

`ItemCache#ensureSubCacheForScaledIndex` method is changed by `gridConnector`, so it will make any grid on the page use the new implementation. That leads to a call from undefined object in case of a grid entirely defined on the client side needs to call this method.

This change stores the original implementation and calls it when the grid doesn't have a `$connector` object.