### PR TITLE
fix: make connector patch ItemCache only once

### DIFF
--- a/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridOnClientAndSlotPage.java
+++ b/vaadin-grid-flow-integration-tests/src/main/java/com/vaadin/flow/component/grid/it/GridOnClientAndSlotPage.java
@@ -2,18 +2,27 @@ package com.vaadin.flow.component.grid.it;
 
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.router.Route;
 
 @Route("grid-on-client-and-slot")
 public class GridOnClientAndSlotPage extends Div {
     public GridOnClientAndSlotPage() {
         GridOnClientAndSlot gridOnClientAndSlot = new GridOnClientAndSlot();
+        
+        gridOnClientAndSlot.add(createGrid());
+        
+        NativeButton addGridButton = new NativeButton("add grid", e -> gridOnClientAndSlot.add(createGrid()));
+        addGridButton.setId("add-new-grid-button");
+
+        add(gridOnClientAndSlot, addGridButton);
+    }
+
+    private Grid<String> createGrid() {
         Grid<String> grid = new Grid<>();
         grid.addColumn(String::toString).setHeader("Column");
         grid.setItems("Item 1", "Item 2", "Item 3", "Item 4");
-        
-        gridOnClientAndSlot.add(grid);
 
-        add(gridOnClientAndSlot);
+        return grid;
     }
 }

--- a/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridOnClientAndServerIT.java
+++ b/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridOnClientAndServerIT.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.component.grid.it;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.openqa.selenium.By;
 
 import com.vaadin.flow.component.grid.testbench.GridTHTDElement;
 import com.vaadin.flow.component.grid.testbench.TreeGridElement;
@@ -34,9 +35,15 @@ public class GridOnClientAndServerIT extends AbstractComponentIT {
     TestBenchElement parent  = $("grid-on-client-and-slot").first();
 
     TreeGridElement treeGrid = parent.$(TreeGridElement.class).id("tree");
-    treeGrid.getExpandToggleElement(0, 0).click();;
+    treeGrid.getExpandToggleElement(0, 0).click();
     GridTHTDElement cell = treeGrid.getCell(1, 0);
 
     Assert.assertEquals("child 1-1", cell.getText().trim());
+
+    findElement(By.id("add-new-grid-button")).click();
+    treeGrid.getExpandToggleElement(3, 0).click();
+    cell = treeGrid.getCell(4, 0);
+
+    Assert.assertEquals("child 2-1", cell.getText().trim());
   }
 }


### PR DESCRIPTION
Previous fix for client and server grids on the same page was to store the original `ensureSubCacheForScaledIndex` method before it was patched by connector, but that introduced a stack overflow error after a second grid is added from the server.

This fix makes ItemCache patching to happen only once the first server grid is added, and prevents it from happening after other grids are added.

Fixes #1077