### PR TITLE
fix: prevent possible memory leak (#1102)

### DIFF
--- a/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
+++ b/vaadin-grid-flow/src/main/java/com/vaadin/flow/component/grid/Grid.java
@@ -40,6 +40,7 @@ import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.ComponentUtil;
+import com.vaadin.flow.component.DetachEvent;
 import com.vaadin.flow.component.Focusable;
 import com.vaadin.flow.component.HasElement;
 import com.vaadin.flow.component.HasSize;
@@ -3011,6 +3012,18 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
     protected void onAttach(AttachEvent attachEvent) {
         super.onAttach(attachEvent);
         updateClientSideSorterIndicators(sortOrder);
+        if (getDataProvider() != null && dataProviderChangeRegistration == null) {
+            handleDataProviderChange(getDataProvider());
+        }
+    }
+
+    @Override
+    protected void onDetach(DetachEvent detachEvent) {
+        if (dataProviderChangeRegistration != null) {
+            dataProviderChangeRegistration.remove();
+            dataProviderChangeRegistration = null;
+        }
+        super.onDetach(detachEvent);
     }
 
     private void setSortOrder(List<GridSortOrder<T>> order,


### PR DESCRIPTION
Cherrypick of #1102 

Prevent possible memory leak when e.g. Grid is removed from layout as data provider listener is not explicitly removed.